### PR TITLE
Replace asset & attribute select dropdowns with `or-attribute-picker` component.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.0",
             "dependencies": {
                 "@lit/context": "^1.1.5",
+                "@openremote/or-attribute-picker": "^1.5.0",
                 "@openremote/or-components": "^1.5.0",
-                "@openremote/or-mwc-components": "^1.5.0",
                 "@vaadin/router": "^2.0.0",
                 "lit": "^3.2.1",
                 "lodash": "^4.17.21",
@@ -34,9 +34,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-            "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -52,10 +52,68 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.6.0.tgz",
+            "integrity": "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/core/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
+            "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-            "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -82,13 +140,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-            "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.6",
+                "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -97,32 +155,14 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -138,27 +178,23 @@
                 "node": "*"
             }
         },
-        "node_modules/@eslint/config-array/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-            "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+            "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.16.0"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-            "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+            "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -192,50 +228,15 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
@@ -251,12 +252,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+        "node_modules/@eslint/eslintrc/node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
             "version": "3.1.2",
@@ -271,27 +275,23 @@
                 "node": "*"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@eslint/js": {
-            "version": "9.24.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
-            "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+            "version": "9.38.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+            "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-            "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -299,27 +299,14 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-            "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+            "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.13.0",
+                "@eslint/core": "^0.16.0",
                 "levn": "^0.4.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-            "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/json-schema": "^7.0.15"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -336,31 +323,17 @@
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
-            }
-        },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -378,9 +351,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-            "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -392,18 +365,14 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -416,20 +385,10 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -438,16 +397,16 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT",
             "peer": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -469,27 +428,27 @@
             "license": "MIT"
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-            "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
+            "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@lit/context": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.5.tgz",
-            "integrity": "sha512-57KyQD9of4RlBXkOIF1N40/BLY1j+1wLB5wRmB207+VtwNIRfXbanLsB6BsnFYXrycOUIp2d8gqTNGwuW1lE9Q==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+            "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@lit/reactive-element": "^1.6.2 || ^2.1.0"
             }
         },
         "node_modules/@lit/reactive-element": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
-            "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
+            "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.2.0"
+                "@lit-labs/ssr-dom-shim": "^1.4.0"
             }
         },
         "node_modules/@material/animation": {
@@ -1060,63 +1019,82 @@
             "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
             "license": "Apache-2.0"
         },
+        "node_modules/@mdi/js": {
+            "version": "5.9.55",
+            "resolved": "https://registry.npmjs.org/@mdi/js/-/js-5.9.55.tgz",
+            "integrity": "sha512-BbeHMgeK2/vjdJIRnx12wvQ6s8xAYfvMmEAVsUx9b+7GiQGQ9Za8jpwp17dMKr9CgKRvemlAM4S7S3QOtEbp4A==",
+            "license": "Apache-2.0"
+        },
         "node_modules/@module-federation/error-codes": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.13.1.tgz",
-            "integrity": "sha512-azgGDBnFRfqlivHOl96ZjlFUFlukESz2Rnnz/pINiSqoBBNjUE0fcAZP4X6jgrVITuEg90YkruZa7pW9I3m7Uw==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
+            "integrity": "sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@module-federation/runtime": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.13.1.tgz",
-            "integrity": "sha512-ZHnYvBquDm49LiHfv6fgagMo/cVJneijNJzfPh6S0CJrPS2Tay1bnTXzy8VA5sdIrESagYPaskKMGIj7YfnPug==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.0.tgz",
+            "integrity": "sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "0.13.1",
-                "@module-federation/runtime-core": "0.13.1",
-                "@module-federation/sdk": "0.13.1"
+                "@module-federation/error-codes": "0.18.0",
+                "@module-federation/runtime-core": "0.18.0",
+                "@module-federation/sdk": "0.18.0"
             }
         },
         "node_modules/@module-federation/runtime-core": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.13.1.tgz",
-            "integrity": "sha512-TfyKfkSAentKeuvSsAItk8s5tqQSMfIRTPN2e1aoaq/kFhE+7blps719csyWSX5Lg5Es7WXKMsXHy40UgtBtuw==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.0.tgz",
+            "integrity": "sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "0.13.1",
-                "@module-federation/sdk": "0.13.1"
+                "@module-federation/error-codes": "0.18.0",
+                "@module-federation/sdk": "0.18.0"
             }
         },
         "node_modules/@module-federation/runtime-tools": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.13.1.tgz",
-            "integrity": "sha512-GEF1pxqLc80osIMZmE8j9UKZSaTm2hX2lql8tgIH/O9yK4wnF06k6LL5Ah+wJt+oJv6Dj55ri/MoxMP4SXoPNA==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.18.0.tgz",
+            "integrity": "sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime": "0.13.1",
-                "@module-federation/webpack-bundler-runtime": "0.13.1"
+                "@module-federation/runtime": "0.18.0",
+                "@module-federation/webpack-bundler-runtime": "0.18.0"
             }
         },
         "node_modules/@module-federation/sdk": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.13.1.tgz",
-            "integrity": "sha512-bmf2FGQ0ymZuxYnw9bIUfhV3y6zDhaqgydEjbl4msObKMLGXZqhse2pTIIxBFpIxR1oONKX/y2FAolDCTlWKiw==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.0.tgz",
+            "integrity": "sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@module-federation/webpack-bundler-runtime": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.13.1.tgz",
-            "integrity": "sha512-QSuSIGa09S8mthbB1L6xERqrz+AzPlHR6D7RwAzssAc+IHf40U6NiTLPzUqp9mmKDhC5Tm0EISU0ZHNeJpnpBQ==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.18.0.tgz",
+            "integrity": "sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime": "0.13.1",
-                "@module-federation/sdk": "0.13.1"
+                "@module-federation/runtime": "0.18.0",
+                "@module-federation/sdk": "0.18.0"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+            "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.5.0",
+                "@emnapi/runtime": "^1.5.0",
+                "@tybys/wasm-util": "^0.10.1"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1158,13 +1136,13 @@
             }
         },
         "node_modules/@openremote/core": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/core/-/core-1.5.0.tgz",
-            "integrity": "sha512-QMb/ZUjcp9wXmbXyJRM2RJi7fgzXSWRsXOqqtVouvACYoz1mpSc0mNCVm0S7lC4Lq1RaijrpBcuZH6m84fBKMQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/core/-/core-1.9.0.tgz",
+            "integrity": "sha512-QfKqRmncumAfHpYVDuMOW/GpVMqExhwktqNP85WT+0ZnTik3j26Xa9kwiPPFb62oA84TWdnTQcMz3S6isVqDTQ==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@openremote/or-icon": "1.5.0",
-                "@openremote/rest": "1.5.0",
+                "@openremote/or-icon": "1.9.0",
+                "@openremote/rest": "1.9.0",
                 "i18next": "^21.5.3",
                 "i18next-http-backend": "^1.3.1",
                 "keycloak-js": "^25.0.1",
@@ -1174,72 +1152,54 @@
                 "url-search-params-polyfill": "^8.1.0"
             }
         },
-        "node_modules/@openremote/core/node_modules/keycloak-js": {
-            "version": "25.0.6",
-            "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.6.tgz",
-            "integrity": "sha512-Km+dc+XfNvY6a4az5jcxTK0zPk52ns9mAxLrHj7lF3V+riVYvQujfHmhayltJDjEpSOJ4C8a57LFNNKnNnRP2g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "js-sha256": "^0.11.0",
-                "jwt-decode": "^4.0.0"
-            }
-        },
         "node_modules/@openremote/model": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/model/-/model-1.5.0.tgz",
-            "integrity": "sha512-6ZpQLB5ecdrmAHDrYFBbeeRNe4N3S+8QP6Gwfk/f+F2y+iM1xZt6AsFJdAiCTQI2RSB4zfpP1Y6n48JutLVvLg==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/model/-/model-1.9.0.tgz",
+            "integrity": "sha512-oVDxgfaVFkj4XkbSRd+an4ExGIO4sYKLT1pvmgTwD47Lpv0+agNx7SQsrwX8iJ5A+n6EKqBdg8w5SeF1fqERXw==",
             "license": "AGPL-3.0-or-later"
         },
+        "node_modules/@openremote/or-asset-tree": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/or-asset-tree/-/or-asset-tree-1.9.0.tgz",
+            "integrity": "sha512-bOdFaDDhNJN+1VDAiPGuVgAyKGOq3n/bWSAZ3AORYRpxV70NFsuFDtCwTyTjPtYbMmiWkG+8HEbCcqBEF7YMqQ==",
+            "license": "AGPL-3.0-or-later",
+            "dependencies": {
+                "@mdi/js": "^5.9.55",
+                "@openremote/core": "1.9.0",
+                "@openremote/model": "1.9.0",
+                "@openremote/or-icon": "1.9.0",
+                "@openremote/or-mwc-components": "1.9.0",
+                "@openremote/or-translate": "1.9.0",
+                "@openremote/rest": "1.9.0",
+                "lit": "^3.3.1",
+                "moment": "^2.29.4"
+            }
+        },
+        "node_modules/@openremote/or-attribute-picker": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/or-attribute-picker/-/or-attribute-picker-1.9.0.tgz",
+            "integrity": "sha512-82nRSIY2hnlFyjZKSbqidxqeb67vZ1wW/oEUDmfndNzVcYvVMkzyVfJjJeEHQx+wZ3aDYAFTGb2HKfJRCpEJhw==",
+            "license": "AGPL-3.0-or-later",
+            "dependencies": {
+                "@openremote/core": "1.9.0",
+                "@openremote/or-asset-tree": "1.9.0",
+                "@openremote/or-mwc-components": "1.9.0",
+                "@openremote/or-translate": "1.9.0",
+                "lit": "^3.3.1"
+            }
+        },
         "node_modules/@openremote/or-components": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-components/-/or-components-1.5.0.tgz",
-            "integrity": "sha512-bONOHCfP6VoBj+YmqKvInRRLE1K3dDOINxvYc6PzYw8uqy+rh6+oPoKtNHpdrQdjHhWPjsx6gGapQeeP6Zu61A==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/or-components/-/or-components-1.9.0.tgz",
+            "integrity": "sha512-Qod6pre/OLLX6p9hmPVI2ZOOhm3B2IcxSgNQ/LS06v+ywvPKHZzyaPRe38cUG3XXAC83Mb6hvm7AX4TheZVBvw==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@material/elevation": "^9.0.0",
-                "@openremote/core": "1.5.0",
-                "lit": "^2.0.2",
+                "@openremote/core": "1.9.0",
+                "@openremote/or-mwc-components": "1.9.0",
+                "ace-builds": "^1.41.0",
+                "lit": "^3.3.1",
                 "simplebar": "^5.3.6"
-            }
-        },
-        "node_modules/@openremote/or-components/node_modules/@lit/reactive-element": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
-            }
-        },
-        "node_modules/@openremote/or-components/node_modules/lit": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-components/node_modules/lit-element": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-components/node_modules/lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@types/trusted-types": "^2.0.2"
             }
         },
         "node_modules/@openremote/or-components/node_modules/simplebar": {
@@ -1257,59 +1217,19 @@
             }
         },
         "node_modules/@openremote/or-icon": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-icon/-/or-icon-1.5.0.tgz",
-            "integrity": "sha512-e70vSwBBtMmjlhapV1QxMlOUSuVkT9emf6XKXu5C9pGYR1QMQnpcuBZlmCyh+eYy3AFREkUsGTEloCGSae0IWA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/or-icon/-/or-icon-1.9.0.tgz",
+            "integrity": "sha512-/yTv2qaGKsJHkn55GodsAYqYl7GmKZlBXz1GdAcRiig/ue2DglwX3mxExKL6rL+wWj0edAflz4hiTl/6SWz/Xg==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@mdi/font": "latest",
-                "lit": "^2.0.2"
-            }
-        },
-        "node_modules/@openremote/or-icon/node_modules/@lit/reactive-element": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
-            }
-        },
-        "node_modules/@openremote/or-icon/node_modules/lit": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-icon/node_modules/lit-element": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-icon/node_modules/lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@types/trusted-types": "^2.0.2"
+                "lit": "^3.3.1"
             }
         },
         "node_modules/@openremote/or-mwc-components": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-mwc-components/-/or-mwc-components-1.5.0.tgz",
-            "integrity": "sha512-WTqwbFFR30Iv7X3oKQgzPbojBEBs8kr6EQS5TqQtzVj/BNWRVXkx1fTpEQaIMRlqxJ/ANbT7XxDUDBY/aT+BuA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/or-mwc-components/-/or-mwc-components-1.9.0.tgz",
+            "integrity": "sha512-Og1kuXM91PEWQYWb8tFVyNwrvbSdhkR8h6H33o+6NaQUwjDI4NmjnGhmXAO5cIBBMjJQOuKuKDmerdOXsA+xjg==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@material/button": "^9.0.0",
@@ -1331,142 +1251,63 @@
                 "@material/switch": "^9.0.0",
                 "@material/tab-bar": "^9.0.0",
                 "@material/textfield": "^9.0.0",
-                "@openremote/core": "1.5.0",
-                "@openremote/or-icon": "1.5.0",
-                "@openremote/or-translate": "1.5.0",
-                "lit": "^2.0.2"
-            }
-        },
-        "node_modules/@openremote/or-mwc-components/node_modules/@lit/reactive-element": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
-            }
-        },
-        "node_modules/@openremote/or-mwc-components/node_modules/lit": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-mwc-components/node_modules/lit-element": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-mwc-components/node_modules/lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@types/trusted-types": "^2.0.2"
+                "@openremote/core": "1.9.0",
+                "@openremote/or-icon": "1.9.0",
+                "@openremote/or-translate": "1.9.0",
+                "lit": "^3.3.1"
             }
         },
         "node_modules/@openremote/or-translate": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-translate/-/or-translate-1.5.0.tgz",
-            "integrity": "sha512-0+25gcw5xdgUBqjuQtr1rSIAoo0BepDPD+4xcDgepD3RCvyke0Ex0kXN/bbl8QpyMuLDzAhVr/tx5x6nvg/g1A==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/or-translate/-/or-translate-1.9.0.tgz",
+            "integrity": "sha512-HZR4lM1PQ3R4TNW+nBR+jCEULKKCAw/ENpcyMB6EjlEq3X33fPC6yeThOcCLzioMSDuPf5+4MYTG+5wN2sVskQ==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "i18next": "^21.5.3",
-                "lit": "^2.0.2"
-            }
-        },
-        "node_modules/@openremote/or-translate/node_modules/@lit/reactive-element": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
-            }
-        },
-        "node_modules/@openremote/or-translate/node_modules/lit": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-translate/node_modules/lit-element": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/@openremote/or-translate/node_modules/lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@types/trusted-types": "^2.0.2"
+                "lit": "^3.3.1"
             }
         },
         "node_modules/@openremote/rest": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@openremote/rest/-/rest-1.5.0.tgz",
-            "integrity": "sha512-HeokiaK6x//GI9BR5MpIz3QKvh5wgbaQ63gKTn12uJss3+qOc9wqh/df1nQWQmrNlCUAnqx521rnmHXvwwl4oQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@openremote/rest/-/rest-1.9.0.tgz",
+            "integrity": "sha512-ZhS78PkBL7u+DJz6uQ1XTIi4YWdKSu6qgqncnKNiAb+kkUlCgTUz0Hzp8EYpTOJazFwieF8Nj92cekI+bWbMjw==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@openremote/model": "1.5.0",
+                "@openremote/model": "1.9.0",
                 "axios": "0.24.0",
                 "qs": "^6.8.0"
             }
         },
         "node_modules/@polka/url": {
-            "version": "1.0.0-next.28",
-            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-            "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@rspack/binding": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.3.10.tgz",
-            "integrity": "sha512-9TjO+Ig5U4VqdYWpBsv01n4d2KsgFfdXGIE7zdHXDDbry0avL0J4109ESqSeP9uC+Bi7ZCF53iaxJRvZDflNVQ==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.8.tgz",
+            "integrity": "sha512-/91CzhRl9r5BIQCgGsS7jA6MDbw1I2BQpbfcUUdkdKl2P79K3Zo/Mw/TvKzS86catwLaUQEgkGRmYawOfPg7ow==",
             "dev": true,
             "license": "MIT",
             "optionalDependencies": {
-                "@rspack/binding-darwin-arm64": "1.3.10",
-                "@rspack/binding-darwin-x64": "1.3.10",
-                "@rspack/binding-linux-arm64-gnu": "1.3.10",
-                "@rspack/binding-linux-arm64-musl": "1.3.10",
-                "@rspack/binding-linux-x64-gnu": "1.3.10",
-                "@rspack/binding-linux-x64-musl": "1.3.10",
-                "@rspack/binding-win32-arm64-msvc": "1.3.10",
-                "@rspack/binding-win32-ia32-msvc": "1.3.10",
-                "@rspack/binding-win32-x64-msvc": "1.3.10"
+                "@rspack/binding-darwin-arm64": "1.5.8",
+                "@rspack/binding-darwin-x64": "1.5.8",
+                "@rspack/binding-linux-arm64-gnu": "1.5.8",
+                "@rspack/binding-linux-arm64-musl": "1.5.8",
+                "@rspack/binding-linux-x64-gnu": "1.5.8",
+                "@rspack/binding-linux-x64-musl": "1.5.8",
+                "@rspack/binding-wasm32-wasi": "1.5.8",
+                "@rspack/binding-win32-arm64-msvc": "1.5.8",
+                "@rspack/binding-win32-ia32-msvc": "1.5.8",
+                "@rspack/binding-win32-x64-msvc": "1.5.8"
             }
         },
         "node_modules/@rspack/binding-darwin-arm64": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.3.10.tgz",
-            "integrity": "sha512-0k/j8OeMSVm5u5Nzckp9Ie7S7hprnvNegebnGr+L6VCyD7sMqm4m+4rLHs99ZklYdH0dZtY2+LrzrtjUZCqfew==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.8.tgz",
+            "integrity": "sha512-spJfpOSN3f7V90ic45/ET2NKB2ujAViCNmqb0iGurMNQtFRq+7Kd+jvVKKGXKBHBbsQrFhidSWbbqy2PBPGK8g==",
             "cpu": [
                 "arm64"
             ],
@@ -1478,9 +1319,9 @@
             ]
         },
         "node_modules/@rspack/binding-darwin-x64": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.3.10.tgz",
-            "integrity": "sha512-jOyqYW/18cgxw60wK5oqJvM194pbD4H99xaif89McNtLkH3npFvBkXBHVWWuOHGoXNX0LhRpHcI89p9b9THQZQ==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.8.tgz",
+            "integrity": "sha512-YFOzeL1IBknBcri8vjUp43dfUBylCeQnD+9O9p0wZmLAw7DtpN5JEOe2AkGo8kdTqJjYKI+cczJPKIw6lu1LWw==",
             "cpu": [
                 "x64"
             ],
@@ -1492,9 +1333,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-gnu": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.3.10.tgz",
-            "integrity": "sha512-zhF5ZNaT/7pxrm8xD3dWG1b4x+FO3LbVeZZG448CjpSo5T57kPD+SaGUU1GcPpn6mexf795x0SVS49aH7/e3Dg==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.8.tgz",
+            "integrity": "sha512-UAWCsOnpkvy8eAVRo0uipbHXDhnoDq5zmqWTMhpga0/a3yzCp2e+fnjZb/qnFNYb5MeL0O1mwMOYgn1M3oHILQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1506,9 +1347,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-musl": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.3.10.tgz",
-            "integrity": "sha512-o3x7IrOSCHK6lcRvdZgsSuOG1CHRQR00xiyLW7kkWmNm7t417LC9xdFWKIK62C5fKXGC5YcTbUkDMnQujespkg==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.8.tgz",
+            "integrity": "sha512-GnSvGT4GjokPSD45cTtE+g7LgghuxSP1MRmvd+Vp/I8pnxTVSTsebRod4TAqyiv+l11nuS8yqNveK9qiOkBLWw==",
             "cpu": [
                 "arm64"
             ],
@@ -1520,9 +1361,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-gnu": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.3.10.tgz",
-            "integrity": "sha512-FMSi28VZhXMr15picOHFynULhqZ/FODPxRIS6uNrvPRYcbNuiO1v+VHV6X88mhOMmJ/aVF6OwjUO/o2l1FVa9Q==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.8.tgz",
+            "integrity": "sha512-XLxh5n/pzUfxsugz/8rVBv+Tx2nqEM+9rharK69kfooDsQNKyz7PANllBQ/v4svJ+W0BRHnDL4qXSGdteZeEjA==",
             "cpu": [
                 "x64"
             ],
@@ -1534,9 +1375,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-musl": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.3.10.tgz",
-            "integrity": "sha512-e0xbY9SlbRGIFz41v1yc0HfREvmgMnLV1bLmTSPK8wI2suIEJ7iYYqsocHOAOk86qLZcxVrTnL6EjUcNaRTWlg==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.8.tgz",
+            "integrity": "sha512-gE0+MZmwF+01p9/svpEESkzkLpBkVUG2o03YMpwXYC/maeRRhWvF8BJ7R3i/Ls/jFGSE87dKX5NbRLVzqksq/w==",
             "cpu": [
                 "x64"
             ],
@@ -1547,10 +1388,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rspack/binding-wasm32-wasi": {
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.8.tgz",
+            "integrity": "sha512-cfg3niNHeJuxuml1Vy9VvaJrI/5TakzoaZvKX2g5S24wfzR50Eyy4JAsZ+L2voWQQp1yMJbmPYPmnTCTxdJQBQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.0.5"
+            }
+        },
         "node_modules/@rspack/binding-win32-arm64-msvc": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.3.10.tgz",
-            "integrity": "sha512-YHJPvEujWeWjU6EUF6sDpaec9rsOtKVvy16YCtGaxRpDQXqfuxibnp6Ge0ZTTrY+joRiWehRA9OUI+3McqI+QA==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.8.tgz",
+            "integrity": "sha512-7i3ZTHFXKfU/9Jm9XhpMkrdkxO7lfeYMNVEGkuU5dyBfRMQj69dRgPL7zJwc2plXiqu9LUOl+TwDNTjap7Q36g==",
             "cpu": [
                 "arm64"
             ],
@@ -1562,9 +1417,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-ia32-msvc": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.3.10.tgz",
-            "integrity": "sha512-2iwSBzVBC89ZSk56MYwgirh3bda2WKmL9I3qPajiTEivChXpX7jp83jAtGE6CPqPYcccYz6nrURTHNUZhqXxVw==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.8.tgz",
+            "integrity": "sha512-7ZPPWO11J+soea1+mnfaPpQt7GIodBM7A86dx6PbXgVEoZmetcWPrCF2NBfXxQWOKJ9L3RYltC4z+ZyXRgMOrw==",
             "cpu": [
                 "ia32"
             ],
@@ -1576,9 +1431,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-x64-msvc": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.3.10.tgz",
-            "integrity": "sha512-ehWJ9Y5Zezj/+uJpiWbt29RZaRIM00f91PWuabM6/sKmHJhdCEE21u5iI3B8DeW/EjJsH8zkI69YYAxJWwGn9A==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.8.tgz",
+            "integrity": "sha512-N/zXQgzIxME3YUzXT8qnyzxjqcnXudWOeDh8CAG9zqTCnCiy16SFfQ/cQgEoLlD9geQntV6jx2GbDDI5kpDGMQ==",
             "cpu": [
                 "x64"
             ],
@@ -1590,18 +1445,17 @@
             ]
         },
         "node_modules/@rspack/cli": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-1.3.10.tgz",
-            "integrity": "sha512-QqO2gvuzddUMf5psvJGyMAoFknAWv7GDKfxi3/PUxbYTsQ0c2O9BqkGx7KA47Xe4OeSGLGhyQYL04t2JnorzjA==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/cli/-/cli-1.5.8.tgz",
+            "integrity": "sha512-CVqxLGTHBLGDJxYRlVNCtbWix+bXLIHxT11225wAXSyn/5/kJYWxJNNy42vjUNNGSP1Va/aI5lse/pCZjn3xNA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.7",
-                "@rspack/dev-server": "1.1.1",
+                "@rspack/dev-server": "~1.1.4",
                 "colorette": "2.0.20",
                 "exit-hook": "^4.0.0",
-                "interpret": "^3.1.1",
-                "rechoir": "^0.8.0",
+                "pirates": "^4.0.7",
                 "webpack-bundle-analyzer": "4.10.2",
                 "yargs": "17.7.2"
             },
@@ -1613,19 +1467,18 @@
             }
         },
         "node_modules/@rspack/core": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.3.10.tgz",
-            "integrity": "sha512-YomvSRGuMUQgCE2rNMdff2q1Z0YpZw/z6m5+PVTMSs9l/q69YKUzpbpSD8YyB5i1DddrRxC2RE34DkrBuwlREQ==",
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.8.tgz",
+            "integrity": "sha512-sUd2LfiDhqYVfvknuoz0+/c+wSpn693xotnG5g1CSWKZArbtwiYzBIVnNlcHGmuoBRsnj/TkSq8dTQ7gwfBroQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime-tools": "0.13.1",
-                "@rspack/binding": "1.3.10",
-                "@rspack/lite-tapable": "1.0.1",
-                "caniuse-lite": "^1.0.30001717"
+                "@module-federation/runtime-tools": "0.18.0",
+                "@rspack/binding": "1.5.8",
+                "@rspack/lite-tapable": "1.0.1"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=18.12.0"
             },
             "peerDependencies": {
                 "@swc/helpers": ">=0.5.1"
@@ -1637,19 +1490,16 @@
             }
         },
         "node_modules/@rspack/dev-server": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-1.1.1.tgz",
-            "integrity": "sha512-9r7vOml2SrFA8cvbcJdSan9wHEo1TPXezF22+s5jvdyAAywg8w7HqDol6TPVv64NUonP1DOdyLxZ+6UW6WZiwg==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rspack/dev-server/-/dev-server-1.1.4.tgz",
+            "integrity": "sha512-kGHYX2jYf3ZiHwVl0aUEPBOBEIG1aWleCDCAi+Jg32KUu3qr/zDUpCEd0wPuHfLEgk0X0xAEYCS6JMO7nBStNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^3.6.0",
-                "express": "^4.21.2",
-                "http-proxy-middleware": "^2.0.7",
-                "mime-types": "^2.1.35",
+                "http-proxy-middleware": "^2.0.9",
                 "p-retry": "^6.2.0",
-                "webpack-dev-middleware": "^7.4.2",
-                "webpack-dev-server": "5.2.0",
+                "webpack-dev-server": "5.2.2",
                 "ws": "^8.18.0"
             },
             "engines": {
@@ -1669,10 +1519,29 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tybys/wasm-util/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@types/body-parser": {
-            "version": "1.19.5",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-            "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+            "version": "1.19.6",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1734,15 +1603,15 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
         },
         "node_modules/@types/express": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+            "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1753,22 +1622,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-            "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "version": "4.19.7",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
+            "integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1779,9 +1635,9 @@
             }
         },
         "node_modules/@types/http-errors": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-            "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1809,18 +1665,18 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.14.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-            "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+            "version": "24.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
+            "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/node-forge": {
-            "version": "1.3.11",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
-            "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+            "version": "1.3.14",
+            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1828,9 +1684,9 @@
             }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.18",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
-            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -1849,13 +1705,12 @@
             "license": "MIT"
         },
         "node_modules/@types/send": {
-            "version": "0.17.4",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
+            "integrity": "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/mime": "^1",
                 "@types/node": "*"
             }
         },
@@ -1870,15 +1725,26 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.7",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-            "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.9.tgz",
+            "integrity": "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
                 "@types/node": "*",
-                "@types/send": "*"
+                "@types/send": "<1"
+            }
+        },
+        "node_modules/@types/serve-static/node_modules/@types/send": {
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+            "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
             }
         },
         "node_modules/@types/sockjs": {
@@ -1908,21 +1774,21 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.1.tgz",
-            "integrity": "sha512-ba0rr4Wfvg23vERs3eB+P3lfj2E+2g3lhWcCVukUuhtcdUx5lSIFZlGFEBHKr+3zizDa/TvZTptdNHVZWAkSBg==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
+            "integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.29.1",
-                "@typescript-eslint/type-utils": "8.29.1",
-                "@typescript-eslint/utils": "8.29.1",
-                "@typescript-eslint/visitor-keys": "8.29.1",
+                "@typescript-eslint/scope-manager": "8.46.2",
+                "@typescript-eslint/type-utils": "8.46.2",
+                "@typescript-eslint/utils": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2",
                 "graphemer": "^1.4.0",
-                "ignore": "^5.3.1",
+                "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.0.1"
+                "ts-api-utils": "^2.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1932,22 +1798,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "@typescript-eslint/parser": "^8.46.2",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.1.tgz",
-            "integrity": "sha512-zczrHVEqEaTwh12gWBIJWj8nx+ayDcCJs06yoNMY0kwjMWDM6+kppljY+BxWI06d2Ja+h4+WdufDcwMnnMEWmg==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
+            "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.29.1",
-                "@typescript-eslint/types": "8.29.1",
-                "@typescript-eslint/typescript-estree": "8.29.1",
-                "@typescript-eslint/visitor-keys": "8.29.1",
+                "@typescript-eslint/scope-manager": "8.46.2",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1959,43 +1825,40 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
+            "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "^2.1.3"
+                "@typescript-eslint/tsconfig-utils": "^8.46.2",
+                "@typescript-eslint/types": "^8.46.2",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">=6.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.1.tgz",
-            "integrity": "sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
+            "integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.29.1",
-                "@typescript-eslint/visitor-keys": "8.29.1"
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2005,17 +1868,35 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
+            "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.1.tgz",
-            "integrity": "sha512-DkDUSDwZVCYN71xA4wzySqqcZsHKic53A4BLqmrWFFpOpNSoxX233lwGu/2135ymTCR04PoKiEEEvN1gFYg4Tw==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
+            "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.29.1",
-                "@typescript-eslint/utils": "8.29.1",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2",
+                "@typescript-eslint/utils": "8.46.2",
                 "debug": "^4.3.4",
-                "ts-api-utils": "^2.0.1"
+                "ts-api-utils": "^2.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2026,38 +1907,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.1.tgz",
-            "integrity": "sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
+            "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2069,20 +1925,22 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.1.tgz",
-            "integrity": "sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
+            "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.29.1",
-                "@typescript-eslint/visitor-keys": "8.29.1",
+                "@typescript-eslint/project-service": "8.46.2",
+                "@typescript-eslint/tsconfig-utils": "8.46.2",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
-                "ts-api-utils": "^2.0.1"
+                "ts-api-utils": "^2.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2092,45 +1950,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.1.tgz",
-            "integrity": "sha512-QAkFEbytSaB8wnmB+DflhUPz6CLbFWE2SnSCrRMEa+KnXIzDYbpsn++1HGvnfAsUY44doDXmvRkO5shlM/3UfA==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
+            "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.29.1",
-                "@typescript-eslint/types": "8.29.1",
-                "@typescript-eslint/typescript-estree": "8.29.1"
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.46.2",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2141,18 +1974,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.1.tgz",
-            "integrity": "sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
+            "integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.29.1",
-                "eslint-visitor-keys": "^4.2.0"
+                "@typescript-eslint/types": "8.46.2",
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2163,9 +1996,9 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2185,12 +2018,6 @@
                 "path-to-regexp": "^6.3.0",
                 "type-fest": "^4.26.1"
             }
-        },
-        "node_modules/@vaadin/router/node_modules/path-to-regexp": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-            "license": "MIT"
         },
         "node_modules/@vaadin/vaadin-development-mode-detector": {
             "version": "2.0.7",
@@ -2400,16 +2227,45 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/accepts/node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/ace-builds": {
+            "version": "1.43.4",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.4.tgz",
+            "integrity": "sha512-8hAxVfo2ImICd69BWlZwZlxe9rxDGDjuUhh+WeWgGDvfBCE+r3lkynkQvIovDz4jcMi8O7bsEaFygaDT+h9sBA==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -2436,15 +2292,15 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             },
             "funding": {
                 "type": "github",
@@ -2468,16 +2324,35 @@
                 }
             }
         },
-        "node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.3"
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
             },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "license": "MIT",
             "peerDependencies": {
-                "ajv": "^8.8.2"
+                "ajv": "^6.9.1"
             }
         },
         "node_modules/ansi-html-community": {
@@ -2563,6 +2438,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.8.18",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz",
+            "integrity": "sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -2617,6 +2502,23 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
+        "node_modules/body-parser/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/body-parser/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/body-parser/node_modules/qs": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -2645,9 +2547,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2668,9 +2570,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+            "version": "4.26.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+            "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2688,10 +2590,11 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001688",
-                "electron-to-chromium": "^1.5.73",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.1"
+                "baseline-browser-mapping": "^2.8.9",
+                "caniuse-lite": "^1.0.30001746",
+                "electron-to-chromium": "^1.5.227",
+                "node-releases": "^2.0.21",
+                "update-browserslist-db": "^1.1.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2779,9 +2682,9 @@
             "license": "MIT"
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001718",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-            "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+            "version": "1.0.30001751",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+            "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2796,7 +2699,8 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0"
+            "license": "CC-BY-4.0",
+            "peer": true
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2813,19 +2717,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -2906,14 +2797,11 @@
             "license": "MIT"
         },
         "node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "dev": true,
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
+            "peer": true
         },
         "node_modules/compressible": {
             "version": "2.0.18",
@@ -2929,9 +2817,9 @@
             }
         },
         "node_modules/compression": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-            "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2939,7 +2827,7 @@
                 "compressible": "~2.0.18",
                 "debug": "2.6.9",
                 "negotiator": "~0.6.4",
-                "on-headers": "~1.0.2",
+                "on-headers": "~1.1.0",
                 "safe-buffer": "5.2.1",
                 "vary": "~1.1.2"
             },
@@ -2947,15 +2835,22 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/compression/node_modules/negotiator": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
+            "dependencies": {
+                "ms": "2.0.0"
             }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -3015,9 +2910,9 @@
             "license": "MIT"
         },
         "node_modules/core-js": {
-            "version": "3.41.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
-            "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+            "version": "3.46.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
+            "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -3083,13 +2978,21 @@
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.0.0"
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/deep-is": {
@@ -3212,9 +3115,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.133",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.133.tgz",
-            "integrity": "sha512-mrR+g6Y1at0GKDlPlMMwLAkI6c47q3d7U/vKS3rGTa3V4xStu18oT4UCPg5ErcAhUqk7swSjXSPUGstOYd2qBw==",
+            "version": "1.5.237",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.237.tgz",
+            "integrity": "sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==",
             "license": "ISC",
             "peer": true
         },
@@ -3245,9 +3148,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+            "version": "5.18.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+            "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3277,9 +3180,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "license": "MIT",
             "peer": true
         },
@@ -3325,33 +3228,32 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.24.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
-            "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
+            "version": "9.38.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+            "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.20.0",
-                "@eslint/config-helpers": "^0.2.0",
-                "@eslint/core": "^0.12.0",
+                "@eslint/config-array": "^0.21.1",
+                "@eslint/config-helpers": "^0.4.1",
+                "@eslint/core": "^0.16.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.24.0",
-                "@eslint/plugin-kit": "^0.2.7",
+                "@eslint/js": "9.38.0",
+                "@eslint/plugin-kit": "^0.4.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.3.0",
-                "eslint-visitor-keys": "^4.2.0",
-                "espree": "^10.3.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -3386,30 +3288,36 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
-            "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
+                "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint-visitor-keys": {
@@ -3425,27 +3333,10 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3453,45 +3344,10 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/eslint/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-            "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3499,16 +3355,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
             }
         },
         "node_modules/eslint/node_modules/glob-parent": {
@@ -3524,12 +3370,15 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/eslint/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+        "node_modules/eslint/node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "3.1.2",
@@ -3544,23 +3393,16 @@
                 "node": "*"
             }
         },
-        "node_modules/eslint/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/espree": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.14.0",
+                "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.0"
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3570,9 +3412,9 @@
             }
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3595,16 +3437,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -3617,21 +3449,11 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/esrecurse/node_modules/estraverse": {
+        "node_modules/estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3733,6 +3555,30 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/express/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/express/node_modules/path-to-regexp": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/express/node_modules/qs": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -3786,9 +3632,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
             "funding": [
                 {
                     "type": "github",
@@ -3869,6 +3715,23 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/finalhandler/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/finalhandler/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3908,9 +3771,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -4039,9 +3902,9 @@
             "peer": true
         },
         "node_modules/globals": {
-            "version": "16.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-            "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4210,9 +4073,9 @@
             }
         },
         "node_modules/http-parser-js": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
-            "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+            "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
             "dev": true,
             "license": "MIT"
         },
@@ -4232,9 +4095,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4312,9 +4175,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4355,24 +4218,14 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/interpret": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
-            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10"
             }
         },
         "node_modules/is-binary-path": {
@@ -4386,22 +4239,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-docker": {
@@ -4473,9 +4310,9 @@
             }
         },
         "node_modules/is-network-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
-            "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+            "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4553,10 +4390,26 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/js-sha256": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
-            "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+            "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -4587,9 +4440,9 @@
             "peer": true
         },
         "node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -4620,6 +4473,16 @@
                 "node": ">=18"
             }
         },
+        "node_modules/keycloak-js": {
+            "version": "25.0.6",
+            "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.6.tgz",
+            "integrity": "sha512-Km+dc+XfNvY6a4az5jcxTK0zPk52ns9mAxLrHj7lF3V+riVYvQujfHmhayltJDjEpSOJ4C8a57LFNNKnNnRP2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "js-sha256": "^0.11.0",
+                "jwt-decode": "^4.0.0"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4631,14 +4494,14 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
-            "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+            "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "picocolors": "^1.0.0",
-                "shell-quote": "^1.8.1"
+                "picocolors": "^1.1.1",
+                "shell-quote": "^1.8.3"
             }
         },
         "node_modules/levn": {
@@ -4656,44 +4519,48 @@
             }
         },
         "node_modules/lit": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-            "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
+            "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@lit/reactive-element": "^2.0.4",
-                "lit-element": "^4.1.0",
-                "lit-html": "^3.2.0"
+                "@lit/reactive-element": "^2.1.0",
+                "lit-element": "^4.2.0",
+                "lit-html": "^3.3.0"
             }
         },
         "node_modules/lit-element": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-            "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
+            "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.2.0",
-                "@lit/reactive-element": "^2.0.4",
-                "lit-html": "^3.2.0"
+                "@lit-labs/ssr-dom-shim": "^1.4.0",
+                "@lit/reactive-element": "^2.1.0",
+                "lit-html": "^3.3.0"
             }
         },
         "node_modules/lit-html": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-            "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
+            "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@types/trusted-types": "^2.0.2"
             }
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+            "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/loader-utils": {
@@ -4730,6 +4597,12 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
             "license": "MIT"
         },
         "node_modules/lodash.debounce": {
@@ -4777,19 +4650,18 @@
             }
         },
         "node_modules/memfs": {
-            "version": "4.17.0",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.0.tgz",
-            "integrity": "sha512-4eirfZ7thblFmqFjywlTmuWVSvccHAJbn1r8qQLzmTO11qcqpohOjmY2mFce6x7x7WtskzRqApPD0hv+Oa74jg==",
+            "version": "4.49.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.49.0.tgz",
+            "integrity": "sha512-L9uC9vGuc4xFybbdOpRLoOAOq1YEBBsocCs5NVW32DfU+CZWWIn3OVF+lB8Gp4ttBVSMazwrTrjv8ussX/e3VQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/json-pack": "^1.0.3",
-                "@jsonjoy.com/util": "^1.3.0",
-                "tree-dump": "^1.0.1",
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
                 "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
             },
             "funding": {
                 "type": "github",
@@ -4813,17 +4685,76 @@
                 "tslib": "2"
             }
         },
+        "node_modules/memfs/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/memfs/node_modules/@jsonjoy.com/json-pack": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz",
-            "integrity": "sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==",
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/base64": "^1.1.1",
-                "@jsonjoy.com/util": "^1.1.2",
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
                 "hyperdyperid": "^1.2.0",
-                "thingies": "^1.20.0"
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
             },
             "engines": {
                 "node": ">=10.0"
@@ -4837,9 +4768,30 @@
             }
         },
         "node_modules/memfs/node_modules/@jsonjoy.com/util": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
-            "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -4854,22 +4806,26 @@
             }
         },
         "node_modules/memfs/node_modules/thingies": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-            "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+            "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
             "dev": true,
-            "license": "Unlicense",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
             },
             "peerDependencies": {
                 "tslib": "^2"
             }
         },
         "node_modules/memfs/node_modules/tree-dump": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
-            "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -5018,9 +4974,9 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
         },
@@ -5046,9 +5002,9 @@
             "license": "MIT"
         },
         "node_modules/negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5093,9 +5049,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.25",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
+            "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
             "license": "MIT",
             "peer": true
         },
@@ -5142,9 +5098,9 @@
             }
         },
         "node_modules/on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5152,16 +5108,16 @@
             }
         },
         "node_modules/open": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-            "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
                 "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
+                "wsl-utils": "^0.1.0"
             },
             "engines": {
                 "node": ">=18"
@@ -5291,18 +5247,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-            "dev": true,
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -5324,6 +5272,16 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pirates": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/platform": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
@@ -5341,9 +5299,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5373,6 +5331,16 @@
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
             },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -5478,55 +5446,6 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
-        "node_modules/raw-loader/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/raw-loader/node_modules/ajv-keywords": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "ajv": "^6.9.1"
-            }
-        },
-        "node_modules/raw-loader/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "license": "MIT"
-        },
-        "node_modules/raw-loader/node_modules/schema-utils": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.8",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5555,19 +5474,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/rechoir": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
-            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve": "^1.20.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5593,27 +5499,6 @@
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.16.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -5647,9 +5532,9 @@
             }
         },
         "node_modules/run-applescript": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5711,15 +5596,14 @@
             "license": "MIT"
         },
         "node_modules/schema-utils": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-            "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
             "license": "MIT",
             "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -5751,9 +5635,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5788,6 +5672,23 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/send/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/send/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/send/node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5797,13 +5698,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
@@ -5832,6 +5726,16 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/serve-index/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
             }
         },
         "node_modules/serve-index/node_modules/depd": {
@@ -5866,6 +5770,13 @@
             "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/serve-index/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/serve-index/node_modules/setprototypeof": {
             "version": "1.1.0",
@@ -5931,9 +5842,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-            "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6016,21 +5927,22 @@
             }
         },
         "node_modules/simplebar": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-6.3.0.tgz",
-            "integrity": "sha512-SQJfKSvUPJxlOhYCpswEn5ke5WQGsgDZNmpScWL+MKXgYpCDTq1bGiv6uWXwSHMYTkMco32fDUL35sVwCMmzCw==",
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-6.3.2.tgz",
+            "integrity": "sha512-l4P1Oma0nply0g+pkrkwfC1SF5WDnIHrgiQDXSDzIdjngUDLkPgZcPGKrOvuFeXoSensfKijjIjDlUJSEp+mLQ==",
             "license": "MIT",
             "dependencies": {
-                "simplebar-core": "^1.3.0"
+                "simplebar-core": "^1.3.2"
             }
         },
         "node_modules/simplebar-core": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.3.0.tgz",
-            "integrity": "sha512-LpWl3w0caz0bl322E68qsrRPpIn+rWBGAaEJ0lUJA7Xpr2sw92AkIhg6VWj988IefLXYh50ILatfAnbNoCFrlA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.3.2.tgz",
+            "integrity": "sha512-qKgTTuTqapjsFGkNhCjyPhysnbZGpQqNmjk0nOYjFN5ordC/Wjvg+RbYCyMSnW60l/Z0ZS82GbNltly6PMUH1w==",
             "license": "MIT",
             "dependencies": {
-                "lodash": "^4.17.21"
+                "lodash": "^4.17.21",
+                "lodash-es": "^4.17.21"
             }
         },
         "node_modules/sirv": {
@@ -6113,56 +6025,6 @@
                 "wbuf": "^1.7.3"
             }
         },
-        "node_modules/spdy-transport/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/spdy-transport/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/spdy/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/spdy/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -6225,53 +6087,41 @@
             }
         },
         "node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=8"
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terser": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-            "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+            "version": "5.44.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+            "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
             "license": "BSD-2-Clause",
             "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
+                "acorn": "^8.15.0",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -6317,12 +6167,62 @@
                 }
             }
         },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+        "node_modules/terser-webpack-plugin/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
         },
         "node_modules/thunky": {
             "version": "1.1.0",
@@ -6403,9 +6303,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.39.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-            "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
@@ -6443,15 +6343,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.29.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.1.tgz",
-            "integrity": "sha512-f8cDkvndhbQMPcysk6CUSGBWV+g1utqdn71P5YKwMumVMOG/5k7cHq0KyG4O52nB0oKS4aN2Tp5+wB4APJGC+w==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.2.tgz",
+            "integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.29.1",
-                "@typescript-eslint/parser": "8.29.1",
-                "@typescript-eslint/utils": "8.29.1"
+                "@typescript-eslint/eslint-plugin": "8.46.2",
+                "@typescript-eslint/parser": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2",
+                "@typescript-eslint/utils": "8.46.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6462,13 +6363,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "license": "MIT"
         },
         "node_modules/unpipe": {
@@ -6565,9 +6466,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-            "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+            "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -6595,21 +6496,23 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.99.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.0.tgz",
-            "integrity": "sha512-//MpHjkKV7dhKheJ1lJuHkR6tv8ycfYy7YVzVhhIpwKuKCu5/Zty/vGpFi0fV2RRAWTYDuj6oKn4vYyLzRh55g==",
+            "version": "5.102.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
+            "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.26.3",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
+                "enhanced-resolve": "^5.17.3",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -6619,11 +6522,11 @@
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.0",
-                "tapable": "^2.1.1",
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
                 "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "watchpack": "^2.4.4",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -6668,6 +6571,16 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/webpack-bundle-analyzer/node_modules/ws": {
             "version": "7.5.10",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -6691,15 +6604,15 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-            "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^4.6.0",
-                "mime-types": "^2.1.31",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
                 "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
@@ -6720,16 +6633,97 @@
                 }
             }
         },
+        "node_modules/webpack-dev-middleware/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.0.tgz",
-            "integrity": "sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
                 "@types/express": "^4.17.21",
+                "@types/express-serve-static-core": "^4.17.21",
                 "@types/serve-index": "^1.9.4",
                 "@types/serve-static": "^1.15.5",
                 "@types/sockjs": "^0.3.36",
@@ -6742,7 +6736,7 @@
                 "connect-history-api-fallback": "^2.0.0",
                 "express": "^4.21.2",
                 "graceful-fs": "^4.2.6",
-                "http-proxy-middleware": "^2.0.7",
+                "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
                 "launch-editor": "^2.6.1",
                 "open": "^10.0.3",
@@ -6777,24 +6771,152 @@
                 }
             }
         },
-        "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+        "node_modules/webpack-dev-server/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/webpack-dev-server/node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
             "engines": {
-                "node": ">= 10"
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+            "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
             "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/webpack/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/webpack/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/webpack/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/webpack/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/webpack/node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/websocket-driver": {
@@ -6877,9 +6999,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-            "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6896,6 +7018,22 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/y18n": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
                 "@lit/context": "^1.1.5",
                 "@openremote/or-attribute-picker": "^1.5.0",
                 "@openremote/or-components": "^1.5.0",
+                "@openremote/or-mwc-components": "^1.5.0",
                 "@vaadin/router": "^2.0.0",
                 "lit": "^3.2.1",
                 "lodash": "^4.17.21",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,9 +9,9 @@
             "version": "0.0.0",
             "dependencies": {
                 "@lit/context": "^1.1.5",
-                "@openremote/or-attribute-picker": "^1.5.0",
-                "@openremote/or-components": "^1.5.0",
-                "@openremote/or-mwc-components": "^1.5.0",
+                "@openremote/or-attribute-picker": "^1.11.3",
+                "@openremote/or-components": "^1.11.3",
+                "@openremote/or-mwc-components": "^1.11.3",
                 "@vaadin/router": "^2.0.0",
                 "lit": "^3.2.1",
                 "lodash": "^4.17.21",
@@ -1137,16 +1137,19 @@
             }
         },
         "node_modules/@openremote/core": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/core/-/core-1.9.0.tgz",
-            "integrity": "sha512-QfKqRmncumAfHpYVDuMOW/GpVMqExhwktqNP85WT+0ZnTik3j26Xa9kwiPPFb62oA84TWdnTQcMz3S6isVqDTQ==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-hHSyUNe5ISCo/T3Bjt+mXJporiP+tJUyR2U0DpiAEjmgE1a/TDSH0Bv/G2t+RAMlnvCH7EjxM4IHUQpDpZARMw==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@openremote/or-icon": "1.9.0",
-                "@openremote/rest": "1.9.0",
+                "@openremote/model": "1.11.3",
+                "@openremote/or-icon": "1.11.3",
+                "@openremote/rest": "1.11.3",
+                "axios": "0.24.0",
                 "i18next": "^21.5.3",
                 "i18next-http-backend": "^1.3.1",
                 "keycloak-js": "^25.0.1",
+                "lodash": "^4.17.21",
                 "moment": "^2.29.4",
                 "platform": "^1.3.6",
                 "qs": "^6.8.0",
@@ -1154,50 +1157,54 @@
             }
         },
         "node_modules/@openremote/model": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/model/-/model-1.9.0.tgz",
-            "integrity": "sha512-oVDxgfaVFkj4XkbSRd+an4ExGIO4sYKLT1pvmgTwD47Lpv0+agNx7SQsrwX8iJ5A+n6EKqBdg8w5SeF1fqERXw==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/model/-/model-1.11.3.tgz",
+            "integrity": "sha512-RFP0DA2BXAakIgDNAVfzsxBV3vPfrWdFsADNQtlUfL4QUrjLnj+tfiAmWdiP0TwcVpZBn2olhJWqGt31I9674Q==",
             "license": "AGPL-3.0-or-later"
         },
         "node_modules/@openremote/or-asset-tree": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-asset-tree/-/or-asset-tree-1.9.0.tgz",
-            "integrity": "sha512-bOdFaDDhNJN+1VDAiPGuVgAyKGOq3n/bWSAZ3AORYRpxV70NFsuFDtCwTyTjPtYbMmiWkG+8HEbCcqBEF7YMqQ==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/or-asset-tree/-/or-asset-tree-1.11.3.tgz",
+            "integrity": "sha512-XdLiAlicNu3lpVTuzIf06mPzY1ixCf6uU+RKUzucZVxcQGVNAYRniJwiyt5av6aWBxkRGFlg0odyZeNBH1z/XQ==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@mdi/js": "^5.9.55",
-                "@openremote/core": "1.9.0",
-                "@openremote/model": "1.9.0",
-                "@openremote/or-icon": "1.9.0",
-                "@openremote/or-mwc-components": "1.9.0",
-                "@openremote/or-translate": "1.9.0",
-                "@openremote/rest": "1.9.0",
+                "@openremote/core": "1.11.3",
+                "@openremote/model": "1.11.3",
+                "@openremote/or-icon": "1.11.3",
+                "@openremote/or-mwc-components": "1.11.3",
+                "@openremote/or-translate": "1.11.3",
                 "lit": "^3.3.1",
-                "moment": "^2.29.4"
+                "lodash": "^4.17.21",
+                "qs": "^6.8.0"
             }
         },
         "node_modules/@openremote/or-attribute-picker": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-attribute-picker/-/or-attribute-picker-1.9.0.tgz",
-            "integrity": "sha512-82nRSIY2hnlFyjZKSbqidxqeb67vZ1wW/oEUDmfndNzVcYvVMkzyVfJjJeEHQx+wZ3aDYAFTGb2HKfJRCpEJhw==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/or-attribute-picker/-/or-attribute-picker-1.11.3.tgz",
+            "integrity": "sha512-V9dDkjB/nsytNTNnUNyDFX7qtHUfZWWvwnra/AVR3o9XwLynFIBQWXuQ5yvPxxxCp6fwwJGUlJVPsldd2gOdrw==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@openremote/core": "1.9.0",
-                "@openremote/or-asset-tree": "1.9.0",
-                "@openremote/or-mwc-components": "1.9.0",
-                "@openremote/or-translate": "1.9.0",
+                "@openremote/core": "1.11.3",
+                "@openremote/model": "1.11.3",
+                "@openremote/or-asset-tree": "1.11.3",
+                "@openremote/or-mwc-components": "1.11.3",
+                "@openremote/or-translate": "1.11.3",
                 "lit": "^3.3.1"
             }
         },
         "node_modules/@openremote/or-components": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-components/-/or-components-1.9.0.tgz",
-            "integrity": "sha512-Qod6pre/OLLX6p9hmPVI2ZOOhm3B2IcxSgNQ/LS06v+ywvPKHZzyaPRe38cUG3XXAC83Mb6hvm7AX4TheZVBvw==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/or-components/-/or-components-1.11.3.tgz",
+            "integrity": "sha512-lidgK6/ETi2T2CWwvACXz4H7+WDR8A+JnJWz/iTenS0gy3pqz5clXcjJBZhx4y86OmPGepG0L88oqO8gi1kAMA==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@material/elevation": "^9.0.0",
-                "@openremote/core": "1.9.0",
-                "@openremote/or-mwc-components": "1.9.0",
+                "@openremote/core": "1.11.3",
+                "@openremote/model": "1.11.3",
+                "@openremote/or-icon": "1.11.3",
+                "@openremote/or-mwc-components": "1.11.3",
+                "@openremote/or-translate": "1.11.3",
                 "ace-builds": "^1.41.0",
                 "lit": "^3.3.1",
                 "simplebar": "^5.3.6"
@@ -1218,21 +1225,23 @@
             }
         },
         "node_modules/@openremote/or-icon": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-icon/-/or-icon-1.9.0.tgz",
-            "integrity": "sha512-/yTv2qaGKsJHkn55GodsAYqYl7GmKZlBXz1GdAcRiig/ue2DglwX3mxExKL6rL+wWj0edAflz4hiTl/6SWz/Xg==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/or-icon/-/or-icon-1.11.3.tgz",
+            "integrity": "sha512-QEVu6wKzR1ucy8WMRFdUvqzUPrT+nMvqSokgfj1A5P1JsiQVMZd4x/F6bGcsO9Z9PmEviHFW2g0C5wUdayudBA==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@mdi/font": "latest",
+                "@openremote/model": "1.11.3",
                 "lit": "^3.3.1"
             }
         },
         "node_modules/@openremote/or-mwc-components": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-mwc-components/-/or-mwc-components-1.9.0.tgz",
-            "integrity": "sha512-Og1kuXM91PEWQYWb8tFVyNwrvbSdhkR8h6H33o+6NaQUwjDI4NmjnGhmXAO5cIBBMjJQOuKuKDmerdOXsA+xjg==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/or-mwc-components/-/or-mwc-components-1.11.3.tgz",
+            "integrity": "sha512-saUnVF1jzBP2+OGyV83ldO1tmvDs51AJwt8T3BSb38XEsCW/RPYwQrDAg0ghcnNxB7HswWWGmVwa6VG4ISM2ng==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
+                "@material/base": "^9.0.0",
                 "@material/button": "^9.0.0",
                 "@material/checkbox": "^9.0.0",
                 "@material/data-table": "^9.0.0",
@@ -1243,25 +1252,32 @@
                 "@material/form-field": "^9.0.0",
                 "@material/icon-button": "^9.0.0",
                 "@material/line-ripple": "^9.0.0",
+                "@material/list": "^9.0.0",
                 "@material/menu": "^9.0.0",
+                "@material/menu-surface": "^9.0.0",
                 "@material/radio": "^9.0.0",
                 "@material/ripple": "^9.0.0",
                 "@material/select": "^9.0.0",
                 "@material/slider": "^9.0.0",
                 "@material/snackbar": "^9.0.0",
                 "@material/switch": "^9.0.0",
+                "@material/tab": "^9.0.0",
                 "@material/tab-bar": "^9.0.0",
+                "@material/tab-indicator": "^9.0.0",
+                "@material/tab-scroller": "^9.0.0",
                 "@material/textfield": "^9.0.0",
-                "@openremote/core": "1.9.0",
-                "@openremote/or-icon": "1.9.0",
-                "@openremote/or-translate": "1.9.0",
-                "lit": "^3.3.1"
+                "@openremote/core": "1.11.3",
+                "@openremote/model": "1.11.3",
+                "@openremote/or-icon": "1.11.3",
+                "@openremote/or-translate": "1.11.3",
+                "lit": "^3.3.1",
+                "moment": "^2.29.4"
             }
         },
         "node_modules/@openremote/or-translate": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/or-translate/-/or-translate-1.9.0.tgz",
-            "integrity": "sha512-HZR4lM1PQ3R4TNW+nBR+jCEULKKCAw/ENpcyMB6EjlEq3X33fPC6yeThOcCLzioMSDuPf5+4MYTG+5wN2sVskQ==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/or-translate/-/or-translate-1.11.3.tgz",
+            "integrity": "sha512-k0TuqsYFfZBj7hBaoLNHYcDqR2+LQ1LZr9EYqw/UuhrSv5EfmiEINNC0XNbQCF9qlpv2Gyh/IZ4LEbv6rbpx4Q==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "i18next": "^21.5.3",
@@ -1269,12 +1285,11 @@
             }
         },
         "node_modules/@openremote/rest": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@openremote/rest/-/rest-1.9.0.tgz",
-            "integrity": "sha512-ZhS78PkBL7u+DJz6uQ1XTIi4YWdKSu6qgqncnKNiAb+kkUlCgTUz0Hzp8EYpTOJazFwieF8Nj92cekI+bWbMjw==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@openremote/rest/-/rest-1.11.3.tgz",
+            "integrity": "sha512-Ut+ZgazeMP4lbnH4JHG7JbJf12UsAAqknArCCHDOTpN4KlnnxN9/eBAPoxPJEYv0q8DbA35ePepbco3WBPIrnA==",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "@openremote/model": "1.9.0",
                 "axios": "0.24.0",
                 "qs": "^6.8.0"
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
         "@lit/context": "^1.1.5",
         "@openremote/or-components": "^1.5.0",
         "@openremote/or-attribute-picker": "^1.5.0",
+        "@openremote/or-mwc-components": "^1.5.0",
         "@vaadin/router": "^2.0.0",
         "lit": "^3.2.1",
         "lodash": "^4.17.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@lit/context": "^1.1.5",
         "@openremote/or-components": "^1.5.0",
-        "@openremote/or-mwc-components": "^1.5.0",
+        "@openremote/or-attribute-picker": "^1.5.0",
         "@vaadin/router": "^2.0.0",
         "lit": "^3.2.1",
         "lodash": "^4.17.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,9 @@
     },
     "dependencies": {
         "@lit/context": "^1.1.5",
-        "@openremote/or-components": "^1.5.0",
-        "@openremote/or-attribute-picker": "^1.5.0",
-        "@openremote/or-mwc-components": "^1.5.0",
+        "@openremote/or-components": "^1.11.3",
+        "@openremote/or-attribute-picker": "^1.11.3",
+        "@openremote/or-mwc-components": "^1.11.3",
         "@vaadin/router": "^2.0.0",
         "lit": "^3.2.1",
         "lodash": "^4.17.21",

--- a/frontend/src/components/custom-asset-attribute-picker.ts
+++ b/frontend/src/components/custom-asset-attribute-picker.ts
@@ -42,7 +42,7 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
     protected _getNoAttributesMessage(): string {
         if (this.showOnlyPredictedDatapointAttrs) {
             // TODO: local translation
-            return "No attributes with 'has predicted data points' configuration item found";
+            return "No attributes with 'has predicted data points' and 'stored data points' configuration item found";
         }
         if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
             return "noDatapointsOrRuleStateAttributes";

--- a/frontend/src/components/custom-asset-attribute-picker.ts
+++ b/frontend/src/components/custom-asset-attribute-picker.ts
@@ -1,0 +1,138 @@
+// Copyright 2025, OpenRemote Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { OrAssetAttributePicker } from "@openremote/or-attribute-picker";
+import { customElement, property } from "lit/decorators.js";
+import { WellknownMetaItems } from "@openremote/model";
+import manager, { DefaultColor5, Util } from "@openremote/core";
+import { OrAssetTree, OrAssetTreeSelectionEvent } from "@openremote/or-asset-tree";
+import { html, unsafeCSS } from "lit";
+import { when } from "lit/directives/when.js";
+import { until } from "lit/directives/until.js";
+
+/**
+ * Extended version of the default or-asset-attribute-picker component.
+ * Adds the ability to filter on hasPredictedDataPoints
+ */
+@customElement('custom-asset-attribute-picker')
+export class CustomAssetAttributePicker extends OrAssetAttributePicker {
+
+    @property({ type: Boolean })
+    public showOnlyPredictedDatapointAttrs = false;
+
+    public setShowOnlyPredictedDatapointAttrs(value: boolean): this {
+        this.showOnlyPredictedDatapointAttrs = value;
+        return this;
+    }
+
+    protected _getNoAttributesMessage(): string {
+        if (this.showOnlyPredictedDatapointAttrs) {
+            // TODO: local translation
+            return "No attributes with 'has predicted data points' configuration item found";
+        }
+        if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
+            return "noDatapointsOrRuleStateAttributes";
+        }
+        if (this.showOnlyDatapointAttrs) {
+            return "noDatapointsAttributes";
+        }
+        if (this.showOnlyRuleStateAttrs) {
+            return "noRuleStateAttributes";
+        }
+        return "noAttributesToShow";
+    }
+
+    protected async _onAssetSelectionChanged(event: OrAssetTreeSelectionEvent) {
+        this._assetAttributes = undefined;
+        if (!this.multiSelect) {
+            this.selectedAttributes = [];
+        }
+        this.addBtn.disabled = this.selectedAttributes.length === 0;
+        const assetTree = event.target as OrAssetTree;
+        assetTree.disabled = true;
+
+        let selectedAsset = event.detail.newNodes.length === 0 ? undefined : event.detail.newNodes[0].asset;
+        this._asset = selectedAsset;
+
+        if (selectedAsset) {
+            const assetResponse = await manager.rest.api.AssetResource.get(selectedAsset.id!);
+            selectedAsset = assetResponse.data;
+
+            if (selectedAsset) {
+                this._assetAttributes = Object.values(selectedAsset.attributes!)
+                    .map(attr => ({ ...attr, id: selectedAsset!.id! }))
+                    .sort(Util.sortByString((attribute) => attribute.name!));
+
+                if (this.attributeFilter) {
+                    this._assetAttributes = this._assetAttributes.filter((attr) => this.attributeFilter!(attr))
+                }
+
+                // Filter by predicted datapoints (requires both hasPredictedDataPoints and storeDataPoints)
+                if (this.showOnlyPredictedDatapointAttrs) {
+                    this._assetAttributes = this._assetAttributes
+                        .filter(e => e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS] && 
+                            e.meta?.[WellknownMetaItems.STOREDATAPOINTS]);
+                } else if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
+                    this._assetAttributes = this._assetAttributes
+                        .filter(e => e.meta && (e.meta[WellknownMetaItems.STOREDATAPOINTS] || e.meta[WellknownMetaItems.RULESTATE] || e.meta[WellknownMetaItems.AGENTLINK]));
+                } else if (this.showOnlyDatapointAttrs) {
+                    this._assetAttributes = this._assetAttributes
+                        .filter(e => e.meta && (e.meta[WellknownMetaItems.STOREDATAPOINTS] || e.meta[WellknownMetaItems.AGENTLINK]));
+                } else if (this.showOnlyRuleStateAttrs) {
+                    this._assetAttributes = this._assetAttributes
+                        .filter(e => e.meta && (e.meta[WellknownMetaItems.RULESTATE] || e.meta[WellknownMetaItems.AGENTLINK]));
+                }
+            }
+        }
+        assetTree.disabled = false;
+    }
+
+    protected _setDialogContent(): void {
+        this.content = () => html`
+            <div class="row" style="display: flex;height: 600px;width: 800px;border-top: 1px solid ${unsafeCSS(DefaultColor5)};">
+                <div class="col" style="width: 260px;overflow: auto;border-right: 1px solid ${unsafeCSS(DefaultColor5)};">
+                    <or-asset-tree id="chart-asset-tree" readonly .selectedIds="${this.selectedAssets.length > 0 ? this.selectedAssets : null}"
+                                   @or-asset-tree-selection="${(ev: OrAssetTreeSelectionEvent) => this._onAssetSelectionChanged(ev)}">
+                    </or-asset-tree>
+                </div>
+                <div class="col" style="flex: 1 1 auto;width: 260px;overflow: auto;">
+                    ${when(this._assetAttributes && this._assetAttributes.length > 0, () => {
+                        const selectedNames = this.selectedAttributes.filter(attrRef => attrRef.id === this._asset?.id).map(attrRef => attrRef.name!);
+                        return html`
+                            <div class="attributes-header">
+                                <or-translate value="attribute_plural"></or-translate>
+                            </div>
+                            ${until(
+                                this._getAttributesTemplate(this._assetAttributes, undefined, selectedNames, this.multiSelect, (attrNames) => this._onAttributesSelect(attrNames)),
+                                html`<or-loading></or-loading>`
+                            )}
+                        `
+                    }, () => html`
+                        <div style="display: flex;align-items: center;text-align: center;height: 100%;padding: 0 20px;">
+                            <span style="width:100%">
+                                <or-translate value="${
+                                    (this._assetAttributes && this._assetAttributes.length === 0) ?
+                                        this._getNoAttributesMessage() : "selectAssetOnTheLeft"}">
+                                </or-translate>
+                            </span>
+                        </div>
+                    `)}
+                </div>
+            </div>
+        `;
+    }
+}

--- a/frontend/src/components/custom-asset-attribute-picker.ts
+++ b/frontend/src/components/custom-asset-attribute-picker.ts
@@ -20,7 +20,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { WellknownMetaItems } from '@openremote/model';
 import manager, { DefaultColor5, Util } from '@openremote/core';
 import { OrAssetTree, OrAssetTreeSelectionEvent } from '@openremote/or-asset-tree';
-import { html, unsafeCSS } from 'lit';
+import { css, html, unsafeCSS } from 'lit';
 import { when } from 'lit/directives/when.js';
 import { until } from 'lit/directives/until.js';
 
@@ -30,6 +30,18 @@ import { until } from 'lit/directives/until.js';
  */
 @customElement('custom-asset-attribute-picker')
 export class CustomAssetAttributePicker extends OrAssetAttributePicker {
+    static get styles() {
+        return [
+            ...(Array.isArray(super.styles) ? super.styles : [super.styles]),
+
+            // Scrim doesn't properly work when embedded in an iframe
+            css`
+                .mdc-dialog .mdc-dialog__scrim {
+                    background-color: transparent !important;
+                }
+            `
+        ];
+    }
     @property({ type: Boolean })
     public showOnlyHasPredictedDatapointsAttrs = false;
 

--- a/frontend/src/components/custom-asset-attribute-picker.ts
+++ b/frontend/src/components/custom-asset-attribute-picker.ts
@@ -31,17 +31,21 @@ import { until } from 'lit/directives/until.js';
 @customElement('custom-asset-attribute-picker')
 export class CustomAssetAttributePicker extends OrAssetAttributePicker {
     @property({ type: Boolean })
-    public showOnlyPredictedDatapointAttrs = false;
+    public showOnlyHasPredictedDatapointsAttrs = false;
 
-    public setShowOnlyPredictedDatapointAttrs(value: boolean): this {
-        this.showOnlyPredictedDatapointAttrs = value;
+    public setShowOnlyHasPredictedDatapointsAttrs(value: boolean): this {
+        this.showOnlyHasPredictedDatapointsAttrs = value;
         return this;
     }
 
     protected _getNoAttributesMessage(): string {
-        if (this.showOnlyPredictedDatapointAttrs) {
+        if (this.showOnlyHasPredictedDatapointsAttrs && this.showOnlyDatapointAttrs) {
             // TODO: local translation
             return "No attributes with 'has predicted data points' and either 'store data points' or 'agent link' configuration item found";
+        }
+        if (this.showOnlyHasPredictedDatapointsAttrs) {
+            // TODO: local translation
+            return "No attributes with 'has predicted data points' configuration item found";
         }
         if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
             return 'noDatapointsOrRuleStateAttributes';
@@ -83,13 +87,15 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
                     this._assetAttributes = this._assetAttributes.filter((attr) => this.attributeFilter!(attr));
                 }
 
-                // Filter by predicted datapoints (requires hasPredictedDataPoints and (storeDataPoints or agentLink))
-                if (this.showOnlyPredictedDatapointAttrs) {
+                // Filter by predicted datapoints + datapoints (requires hasPredictedDataPoints and (storeDataPoints or agentLink))
+                if (this.showOnlyHasPredictedDatapointsAttrs && this.showOnlyDatapointAttrs) {
                     this._assetAttributes = this._assetAttributes.filter(
                         (e) =>
                             e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS] &&
                             (e.meta?.[WellknownMetaItems.STOREDATAPOINTS] || e.meta?.[WellknownMetaItems.AGENTLINK])
                     );
+                } else if (this.showOnlyHasPredictedDatapointsAttrs) {
+                    this._assetAttributes = this._assetAttributes.filter((e) => e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS]);
                 } else if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
                     this._assetAttributes = this._assetAttributes.filter(
                         (e) =>

--- a/frontend/src/components/custom-asset-attribute-picker.ts
+++ b/frontend/src/components/custom-asset-attribute-picker.ts
@@ -41,7 +41,7 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
     protected _getNoAttributesMessage(): string {
         if (this.showOnlyPredictedDatapointAttrs) {
             // TODO: local translation
-            return "No attributes with 'has predicted data points' and 'stored data points' configuration item found";
+            return "No attributes with 'has predicted data points' and either 'store data points' or 'agent link' configuration item found";
         }
         if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
             return 'noDatapointsOrRuleStateAttributes';
@@ -55,6 +55,9 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
         return 'noAttributesToShow';
     }
 
+    /**
+     * Duplicated method from the component source code, so we can override it and add our own filtering logic.
+     */
     protected async _onAssetSelectionChanged(event: OrAssetTreeSelectionEvent) {
         this._assetAttributes = undefined;
         if (!this.multiSelect) {
@@ -80,10 +83,12 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
                     this._assetAttributes = this._assetAttributes.filter((attr) => this.attributeFilter!(attr));
                 }
 
-                // Filter by predicted datapoints (requires both hasPredictedDataPoints and storeDataPoints)
+                // Filter by predicted datapoints (requires hasPredictedDataPoints and (storeDataPoints or agentLink))
                 if (this.showOnlyPredictedDatapointAttrs) {
                     this._assetAttributes = this._assetAttributes.filter(
-                        (e) => e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS] && e.meta?.[WellknownMetaItems.STOREDATAPOINTS]
+                        (e) =>
+                            e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS] &&
+                            (e.meta?.[WellknownMetaItems.STOREDATAPOINTS] || e.meta?.[WellknownMetaItems.AGENTLINK])
                     );
                 } else if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
                     this._assetAttributes = this._assetAttributes.filter(
@@ -107,6 +112,9 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
         assetTree.disabled = false;
     }
 
+    /**
+     * Duplicated method from the component source code, so we can override it and add additional content.
+     */
     protected _setDialogContent(): void {
         this.content = () => html`
             <div class="row" style="display: flex;height: 600px;width: 800px;border-top: 1px solid ${unsafeCSS(DefaultColor5)};">

--- a/frontend/src/components/custom-asset-attribute-picker.ts
+++ b/frontend/src/components/custom-asset-attribute-picker.ts
@@ -15,14 +15,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { OrAssetAttributePicker } from "@openremote/or-attribute-picker";
-import { customElement, property } from "lit/decorators.js";
-import { WellknownMetaItems } from "@openremote/model";
-import manager, { DefaultColor5, Util } from "@openremote/core";
-import { OrAssetTree, OrAssetTreeSelectionEvent } from "@openremote/or-asset-tree";
-import { html, unsafeCSS } from "lit";
-import { when } from "lit/directives/when.js";
-import { until } from "lit/directives/until.js";
+import { OrAssetAttributePicker } from '@openremote/or-attribute-picker';
+import { customElement, property } from 'lit/decorators.js';
+import { WellknownMetaItems } from '@openremote/model';
+import manager, { DefaultColor5, Util } from '@openremote/core';
+import { OrAssetTree, OrAssetTreeSelectionEvent } from '@openremote/or-asset-tree';
+import { html, unsafeCSS } from 'lit';
+import { when } from 'lit/directives/when.js';
+import { until } from 'lit/directives/until.js';
 
 /**
  * Extended version of the default or-asset-attribute-picker component.
@@ -30,7 +30,6 @@ import { until } from "lit/directives/until.js";
  */
 @customElement('custom-asset-attribute-picker')
 export class CustomAssetAttributePicker extends OrAssetAttributePicker {
-
     @property({ type: Boolean })
     public showOnlyPredictedDatapointAttrs = false;
 
@@ -45,15 +44,15 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
             return "No attributes with 'has predicted data points' and 'stored data points' configuration item found";
         }
         if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
-            return "noDatapointsOrRuleStateAttributes";
+            return 'noDatapointsOrRuleStateAttributes';
         }
         if (this.showOnlyDatapointAttrs) {
-            return "noDatapointsAttributes";
+            return 'noDatapointsAttributes';
         }
         if (this.showOnlyRuleStateAttrs) {
-            return "noRuleStateAttributes";
+            return 'noRuleStateAttributes';
         }
-        return "noAttributesToShow";
+        return 'noAttributesToShow';
     }
 
     protected async _onAssetSelectionChanged(event: OrAssetTreeSelectionEvent) {
@@ -74,27 +73,34 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
 
             if (selectedAsset) {
                 this._assetAttributes = Object.values(selectedAsset.attributes!)
-                    .map(attr => ({ ...attr, id: selectedAsset!.id! }))
+                    .map((attr) => ({ ...attr, id: selectedAsset!.id! }))
                     .sort(Util.sortByString((attribute) => attribute.name!));
 
                 if (this.attributeFilter) {
-                    this._assetAttributes = this._assetAttributes.filter((attr) => this.attributeFilter!(attr))
+                    this._assetAttributes = this._assetAttributes.filter((attr) => this.attributeFilter!(attr));
                 }
 
                 // Filter by predicted datapoints (requires both hasPredictedDataPoints and storeDataPoints)
                 if (this.showOnlyPredictedDatapointAttrs) {
-                    this._assetAttributes = this._assetAttributes
-                        .filter(e => e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS] && 
-                            e.meta?.[WellknownMetaItems.STOREDATAPOINTS]);
+                    this._assetAttributes = this._assetAttributes.filter(
+                        (e) => e.meta?.[WellknownMetaItems.HASPREDICTEDDATAPOINTS] && e.meta?.[WellknownMetaItems.STOREDATAPOINTS]
+                    );
                 } else if (this.showOnlyDatapointAttrs && this.showOnlyRuleStateAttrs) {
-                    this._assetAttributes = this._assetAttributes
-                        .filter(e => e.meta && (e.meta[WellknownMetaItems.STOREDATAPOINTS] || e.meta[WellknownMetaItems.RULESTATE] || e.meta[WellknownMetaItems.AGENTLINK]));
+                    this._assetAttributes = this._assetAttributes.filter(
+                        (e) =>
+                            e.meta &&
+                            (e.meta[WellknownMetaItems.STOREDATAPOINTS] ||
+                                e.meta[WellknownMetaItems.RULESTATE] ||
+                                e.meta[WellknownMetaItems.AGENTLINK])
+                    );
                 } else if (this.showOnlyDatapointAttrs) {
-                    this._assetAttributes = this._assetAttributes
-                        .filter(e => e.meta && (e.meta[WellknownMetaItems.STOREDATAPOINTS] || e.meta[WellknownMetaItems.AGENTLINK]));
+                    this._assetAttributes = this._assetAttributes.filter(
+                        (e) => e.meta && (e.meta[WellknownMetaItems.STOREDATAPOINTS] || e.meta[WellknownMetaItems.AGENTLINK])
+                    );
                 } else if (this.showOnlyRuleStateAttrs) {
-                    this._assetAttributes = this._assetAttributes
-                        .filter(e => e.meta && (e.meta[WellknownMetaItems.RULESTATE] || e.meta[WellknownMetaItems.AGENTLINK]));
+                    this._assetAttributes = this._assetAttributes.filter(
+                        (e) => e.meta && (e.meta[WellknownMetaItems.RULESTATE] || e.meta[WellknownMetaItems.AGENTLINK])
+                    );
                 }
             }
         }
@@ -105,32 +111,50 @@ export class CustomAssetAttributePicker extends OrAssetAttributePicker {
         this.content = () => html`
             <div class="row" style="display: flex;height: 600px;width: 800px;border-top: 1px solid ${unsafeCSS(DefaultColor5)};">
                 <div class="col" style="width: 260px;overflow: auto;border-right: 1px solid ${unsafeCSS(DefaultColor5)};">
-                    <or-asset-tree id="chart-asset-tree" readonly .selectedIds="${this.selectedAssets.length > 0 ? this.selectedAssets : null}"
-                                   @or-asset-tree-selection="${(ev: OrAssetTreeSelectionEvent) => this._onAssetSelectionChanged(ev)}">
+                    <or-asset-tree
+                        id="chart-asset-tree"
+                        readonly
+                        .selectedIds="${this.selectedAssets.length > 0 ? this.selectedAssets : null}"
+                        @or-asset-tree-selection="${(ev: OrAssetTreeSelectionEvent) => this._onAssetSelectionChanged(ev)}"
+                    >
                     </or-asset-tree>
                 </div>
                 <div class="col" style="flex: 1 1 auto;width: 260px;overflow: auto;">
-                    ${when(this._assetAttributes && this._assetAttributes.length > 0, () => {
-                        const selectedNames = this.selectedAttributes.filter(attrRef => attrRef.id === this._asset?.id).map(attrRef => attrRef.name!);
-                        return html`
-                            <div class="attributes-header">
-                                <or-translate value="attribute_plural"></or-translate>
+                    ${when(
+                        this._assetAttributes && this._assetAttributes.length > 0,
+                        () => {
+                            const selectedNames = this.selectedAttributes
+                                .filter((attrRef) => attrRef.id === this._asset?.id)
+                                .map((attrRef) => attrRef.name!);
+                            return html`
+                                <div class="attributes-header">
+                                    <or-translate value="attribute_plural"></or-translate>
+                                </div>
+                                ${until(
+                                    this._getAttributesTemplate(
+                                        this._assetAttributes,
+                                        undefined,
+                                        selectedNames,
+                                        this.multiSelect,
+                                        (attrNames) => this._onAttributesSelect(attrNames)
+                                    ),
+                                    html`<or-loading></or-loading>`
+                                )}
+                            `;
+                        },
+                        () => html`
+                            <div style="display: flex;align-items: center;text-align: center;height: 100%;padding: 0 20px;">
+                                <span style="width:100%">
+                                    <or-translate
+                                        value="${this._assetAttributes && this._assetAttributes.length === 0
+                                            ? this._getNoAttributesMessage()
+                                            : 'selectAssetOnTheLeft'}"
+                                    >
+                                    </or-translate>
+                                </span>
                             </div>
-                            ${until(
-                                this._getAttributesTemplate(this._assetAttributes, undefined, selectedNames, this.multiSelect, (attrNames) => this._onAttributesSelect(attrNames)),
-                                html`<or-loading></or-loading>`
-                            )}
                         `
-                    }, () => html`
-                        <div style="display: flex;align-items: center;text-align: center;height: 100%;padding: 0 20px;">
-                            <span style="width:100%">
-                                <or-translate value="${
-                                    (this._assetAttributes && this._assetAttributes.length === 0) ?
-                                        this._getNoAttributesMessage() : "selectAssetOnTheLeft"}">
-                                </or-translate>
-                            </span>
-                        </div>
-                    `)}
+                    )}
                 </div>
             </div>
         `;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -40,7 +40,7 @@ const DEFAULT_MANAGER_CONFIG: ManagerConfig = {
     realm: undefined,
     consoleAutoEnable: true,
     loadTranslations: ['or'],
-    eventProviderType: EventProviderType.POLLING
+    eventProviderType: EventProviderType.WEBSOCKET
 };
 
 async function init() {

--- a/frontend/src/pages/app-layout.ts
+++ b/frontend/src/pages/app-layout.ts
@@ -59,6 +59,9 @@ export class AppLayout extends LitElement {
         // Initialize the OpenRemote manager rest api using the authenticated realm
         manager.rest.initialise(`${ML_OR_URL}/api/${authRealm}`);
 
+        // Update the manager display realm so components properly use the correct realm
+        manager.displayRealm = this.realm;
+
         // Set the service UI theme based on the given realm
         setRealmTheme(this.realm);
     }

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -343,7 +343,8 @@ export class PageConfigEditor extends LitElement {
 
         const dialog = showDialog(
             new CustomAssetAttributePicker()
-                .setShowOnlyPredictedDatapointAttrs(true)
+                .setShowOnlyHasPredictedDatapointsAttrs(true)
+                .setShowOnlyDatapointAttrs(true)
                 .setMultiSelect(false)
                 .setSelectedAttributes(currentSelection)
         );

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -104,7 +104,7 @@ export class PageConfigEditor extends LitElement {
             .selected-attr {
                 display: flex;
                 align-items: center;
-                padding: 0 10px 0 8px;
+                padding: 0 16px 0 8px;
                 gap: 8px;
                 cursor: pointer;
             }
@@ -529,6 +529,7 @@ export class PageConfigEditor extends LitElement {
                                 <or-mwc-input
                                     class="select-attr"
                                     type="${InputType.BUTTON}"
+                                    icon="magnify"
                                     label="Select regressor"
                                     @click="${() => this.openRegressorDialog(index)}"
                                 ></or-mwc-input>

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -97,8 +97,8 @@ export class PageConfigEditor extends LitElement {
             }
 
             .select-attr {
-              flex: none;
-              min-width: 125px;
+                flex: none;
+                min-width: 125px;
             }
 
             .selected-attr {
@@ -274,17 +274,17 @@ export class PageConfigEditor extends LitElement {
 
     // Open dialog to select target attribute
     protected openTargetDialog() {
-        const currentSelection = this.formData.target.asset_id && this.formData.target.attribute_name
-            ? [{ id: this.formData.target.asset_id, name: this.formData.target.attribute_name }]
-            : [];
+        const currentSelection =
+            this.formData.target.asset_id && this.formData.target.attribute_name
+                ? [{ id: this.formData.target.asset_id, name: this.formData.target.attribute_name }]
+                : [];
 
         // disable scrolling
         document.body.style.overflow = 'hidden';
 
-        const dialog = showDialog(new CustomAssetAttributePicker()
-            .setShowOnlyDatapointAttrs(true)
-            .setMultiSelect(false)
-            .setSelectedAttributes(currentSelection));
+        const dialog = showDialog(
+            new CustomAssetAttributePicker().setShowOnlyDatapointAttrs(true).setMultiSelect(false).setSelectedAttributes(currentSelection)
+        );
 
         // restore scrolling
         const restoreScroll = () => {
@@ -314,7 +314,7 @@ export class PageConfigEditor extends LitElement {
     // Load asset data for regressor
     protected async loadRegressorAsset(index: number) {
         if (!this.formData.regressors) return;
-        
+
         const regressor = this.formData.regressors[index];
         if (regressor.asset_id && regressor.attribute_name) {
             try {
@@ -336,16 +336,17 @@ export class PageConfigEditor extends LitElement {
         }
 
         const regressor = this.formData.regressors[index];
-        const currentSelection = regressor.asset_id && regressor.attribute_name
-            ? [{ id: regressor.asset_id, name: regressor.attribute_name }]
-            : [];
+        const currentSelection =
+            regressor.asset_id && regressor.attribute_name ? [{ id: regressor.asset_id, name: regressor.attribute_name }] : [];
 
         document.body.style.overflow = 'hidden';
 
-        const dialog = showDialog(new CustomAssetAttributePicker()
-            .setShowOnlyPredictedDatapointAttrs(true)
-            .setMultiSelect(false)
-            .setSelectedAttributes(currentSelection));
+        const dialog = showDialog(
+            new CustomAssetAttributePicker()
+                .setShowOnlyPredictedDatapointAttrs(true)
+                .setMultiSelect(false)
+                .setSelectedAttributes(currentSelection)
+        );
 
         const restoreScroll = () => {
             document.body.style.overflow = '';
@@ -393,7 +394,7 @@ export class PageConfigEditor extends LitElement {
             this.modelConfig = await APIService.getModelConfig(this.realm, this.configId);
             // Create a deep copy of the model config for the form data
             this.formData = structuredClone(this.modelConfig);
-            
+
             // Load asset data for displaying
             await this.loadTargetAsset();
             if (this.formData.regressors) {
@@ -401,7 +402,7 @@ export class PageConfigEditor extends LitElement {
                     await this.loadRegressorAsset(i);
                 }
             }
-            
+
             this.loading = false;
             return;
         } catch (err) {
@@ -513,8 +514,12 @@ export class PageConfigEditor extends LitElement {
                             () => {
                                 const asset = this.regressorAssets.get(index);
                                 const attribute = asset?.attributes?.[regressor.attribute_name];
-                                const descriptors = attribute ? AssetModelUtil.getAttributeAndValueDescriptors(asset.type, regressor.attribute_name, attribute) : [];
-                                const label = attribute ? Util.getAttributeLabel(attribute, descriptors[0], asset.type, true) : regressor.attribute_name;
+                                const descriptors = attribute
+                                    ? AssetModelUtil.getAttributeAndValueDescriptors(asset.type, regressor.attribute_name, attribute)
+                                    : [];
+                                const label = attribute
+                                    ? Util.getAttributeLabel(attribute, descriptors[0], asset.type, true)
+                                    : regressor.attribute_name;
                                 return html`
                                     <div class="selected-attr" @click="${() => this.openRegressorDialog(index)}">
                                         ${getAssetDescriptorIconTemplate(AssetModelUtil.getAssetDescriptor(asset.type))}
@@ -702,8 +707,16 @@ export class PageConfigEditor extends LitElement {
                                 this.formData.target.asset_id && this.formData.target.attribute_name && this.targetAsset,
                                 () => {
                                     const attribute = this.targetAsset.attributes?.[this.formData.target.attribute_name];
-                                    const descriptors = attribute ? AssetModelUtil.getAttributeAndValueDescriptors(this.targetAsset.type, this.formData.target.attribute_name, attribute) : [];
-                                    const label = attribute ? Util.getAttributeLabel(attribute, descriptors[0], this.targetAsset.type, true) : this.formData.target.attribute_name;
+                                    const descriptors = attribute
+                                        ? AssetModelUtil.getAttributeAndValueDescriptors(
+                                              this.targetAsset.type,
+                                              this.formData.target.attribute_name,
+                                              attribute
+                                          )
+                                        : [];
+                                    const label = attribute
+                                        ? Util.getAttributeLabel(attribute, descriptors[0], this.targetAsset.type, true)
+                                        : this.formData.target.attribute_name;
                                     return html`
                                         <div class="selected-attr" @click="${this.openTargetDialog}">
                                             ${getAssetDescriptorIconTemplate(AssetModelUtil.getAssetDescriptor(this.targetAsset.type))}

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { css, html, LitElement, PropertyValues } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
@@ -343,8 +343,8 @@ export class PageConfigEditor extends LitElement {
 
         const dialog = showDialog(
             new CustomAssetAttributePicker()
-                .setShowOnlyHasPredictedDatapointsAttrs(true)
-                .setShowOnlyDatapointAttrs(true)
+                .setShowOnlyHasPredictedDatapointsAttrs(true) // has future datapoints
+                .setShowOnlyDatapointAttrs(true) // has past datapoints
                 .setMultiSelect(false)
                 .setSelectedAttributes(currentSelection)
         );
@@ -370,8 +370,7 @@ export class PageConfigEditor extends LitElement {
         dialog.addEventListener('or-mwc-dialog-closed', restoreScroll);
     }
 
-    willUpdate(_changedProperties: PropertyValues): void {
-        void _changedProperties; // Explicitly acknowledge unused parameter
+    willUpdate(): void {
         this.isValid = this.isFormValid();
         this.modified = this.isFormModified();
     }

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -264,7 +264,7 @@ export class PageConfigEditor extends LitElement {
                 const response = await manager.rest.api.AssetResource.get(this.formData.target.asset_id);
                 this.targetAsset = response.data;
             } catch (err) {
-                console.error("Failed to load target asset:", err);
+                console.error('Failed to load target asset:', err);
                 this.targetAsset = null;
             }
         } else {
@@ -322,7 +322,7 @@ export class PageConfigEditor extends LitElement {
                 this.regressorAssets.set(index, response.data);
                 this.regressorAssets = new Map(this.regressorAssets);
             } catch (err) {
-                console.error("Failed to load regressor asset:", err);
+                console.error('Failed to load regressor asset:', err);
                 this.regressorAssets.delete(index);
                 this.regressorAssets = new Map(this.regressorAssets);
             }
@@ -407,7 +407,7 @@ export class PageConfigEditor extends LitElement {
             return;
         } catch (err) {
             this.loading = false;
-            console.error("Failed to load config:", err);
+            console.error('Failed to load config:', err);
             this.error = `Failed to retrieve the forecast configuration`;
         }
     }
@@ -436,7 +436,7 @@ export class PageConfigEditor extends LitElement {
                 Router.go(`${this.rootPath}/${modelConfig.realm}/configs/${modelConfig.id}`);
             }
         } catch (error) {
-            console.error("Failed to save config:", error);
+            console.error('Failed to save config:', error);
             showSnackbar(undefined, 'Failed to save the config');
         }
     }

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -34,7 +34,7 @@ import { manager, Util } from '@openremote/core';
 import { CustomAssetAttributePicker } from '../components/custom-asset-attribute-picker';
 import { OrAssetAttributePickerPickedEvent } from '@openremote/or-attribute-picker';
 import { getAssetDescriptorIconTemplate } from '@openremote/or-icon';
-import { AssetModelUtil } from '@openremote/model';
+import { Asset, AssetModelUtil } from '@openremote/model';
 
 @customElement('page-config-editor')
 export class PageConfigEditor extends LitElement {
@@ -171,10 +171,10 @@ export class PageConfigEditor extends LitElement {
     protected error: string | null = null;
 
     @state()
-    protected targetAsset: any = null;
+    protected targetAsset: Asset | null = null;
 
     @state()
-    protected regressorAssets: Map<number, any> = new Map();
+    protected regressorAssets: Map<number, Asset> = new Map();
 
     protected readonly rootPath = getRootPath();
 
@@ -291,7 +291,7 @@ export class PageConfigEditor extends LitElement {
             document.body.style.overflow = '';
         };
 
-        dialog.addEventListener(OrAssetAttributePickerPickedEvent.NAME, async (ev: any) => {
+        dialog.addEventListener(OrAssetAttributePickerPickedEvent.NAME, async (ev: OrAssetAttributePickerPickedEvent) => {
             const selected = ev.detail[0];
             if (selected) {
                 this.formData = {
@@ -353,7 +353,7 @@ export class PageConfigEditor extends LitElement {
             document.body.style.overflow = '';
         };
 
-        dialog.addEventListener(OrAssetAttributePickerPickedEvent.NAME, async (ev: any) => {
+        dialog.addEventListener(OrAssetAttributePickerPickedEvent.NAME, async (ev: OrAssetAttributePickerPickedEvent) => {
             const selected = ev.detail[0];
             if (selected && this.formData.regressors) {
                 this.formData.regressors[index] = {
@@ -512,8 +512,8 @@ export class PageConfigEditor extends LitElement {
                         ${when(
                             regressor.asset_id && regressor.attribute_name && this.regressorAssets.has(index),
                             () => {
-                                const asset = this.regressorAssets.get(index);
-                                const attribute = asset?.attributes?.[regressor.attribute_name];
+                                const asset = this.regressorAssets.get(index)!;
+                                const attribute = asset.attributes?.[regressor.attribute_name];
                                 const descriptors = attribute
                                     ? AssetModelUtil.getAttributeAndValueDescriptors(asset.type, regressor.attribute_name, attribute)
                                     : [];
@@ -536,7 +536,7 @@ export class PageConfigEditor extends LitElement {
                                     type="${InputType.BUTTON}"
                                     icon="magnify"
                                     label="Select regressor"
-                                    @click="${() => this.openRegressorDialog(index)}"
+                                    @or-mwc-input-changed="${() => this.openRegressorDialog(index)}"
                                 ></or-mwc-input>
                             `
                         )}
@@ -706,22 +706,22 @@ export class PageConfigEditor extends LitElement {
                             ${when(
                                 this.formData.target.asset_id && this.formData.target.attribute_name && this.targetAsset,
                                 () => {
-                                    const attribute = this.targetAsset.attributes?.[this.formData.target.attribute_name];
+                                    const attribute = this.targetAsset!.attributes?.[this.formData.target.attribute_name];
                                     const descriptors = attribute
                                         ? AssetModelUtil.getAttributeAndValueDescriptors(
-                                              this.targetAsset.type,
+                                              this.targetAsset!.type,
                                               this.formData.target.attribute_name,
                                               attribute
                                           )
                                         : [];
                                     const label = attribute
-                                        ? Util.getAttributeLabel(attribute, descriptors[0], this.targetAsset.type, true)
+                                        ? Util.getAttributeLabel(attribute, descriptors[0], this.targetAsset!.type, true)
                                         : this.formData.target.attribute_name;
                                     return html`
                                         <div class="selected-attr" @click="${this.openTargetDialog}">
-                                            ${getAssetDescriptorIconTemplate(AssetModelUtil.getAssetDescriptor(this.targetAsset.type))}
+                                            ${getAssetDescriptorIconTemplate(AssetModelUtil.getAssetDescriptor(this.targetAsset!.type))}
                                             <div class="selected-attr-text">
-                                                <span>${this.targetAsset.name}</span>
+                                                <span>${this.targetAsset!.name}</span>
                                                 <span>${label}</span>
                                             </div>
                                         </div>

--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -264,7 +264,7 @@ export class PageConfigEditor extends LitElement {
                 const response = await manager.rest.api.AssetResource.get(this.formData.target.asset_id);
                 this.targetAsset = response.data;
             } catch (err) {
-                console.error(err);
+                console.error("Failed to load target asset:", err);
                 this.targetAsset = null;
             }
         } else {
@@ -322,7 +322,7 @@ export class PageConfigEditor extends LitElement {
                 this.regressorAssets.set(index, response.data);
                 this.regressorAssets = new Map(this.regressorAssets);
             } catch (err) {
-                console.error(err);
+                console.error("Failed to load regressor asset:", err);
                 this.regressorAssets.delete(index);
                 this.regressorAssets = new Map(this.regressorAssets);
             }
@@ -407,7 +407,7 @@ export class PageConfigEditor extends LitElement {
             return;
         } catch (err) {
             this.loading = false;
-            console.error(err);
+            console.error("Failed to load config:", err);
             this.error = `Failed to retrieve the forecast configuration`;
         }
     }
@@ -436,7 +436,7 @@ export class PageConfigEditor extends LitElement {
                 Router.go(`${this.rootPath}/${modelConfig.realm}/configs/${modelConfig.id}`);
             }
         } catch (error) {
-            console.error(error);
+            console.error("Failed to save config:", error);
             showSnackbar(undefined, 'Failed to save the config');
         }
     }


### PR DESCRIPTION
Closes #53
Closes #52 

### Changes
This PR replaces the current method of selecting assets and their attributes (dropdowns) with the `or-attribute-picker` component.

- Added `or-attribute-picker` dependency.  
- Added `custom-asset-attribute-picker.ts`, which extends/overrides `OrAssetAttributePicker`.  
  - Reasoning: for regressors, we only want to show attributes that have both `storeDataPoints` and either `hasPredictedDataPoints` or `hasAgentLink` meta items.  
  - This resolves issue #52.  
- Updated the manager config `eventProviderType` to `WEBSOCKET` so that the `or-asset-tree` component inside the attribute picker functions correctly, as it relies on WebSockets.  
- The service now locally updates the `manager.displayRealm` so that `or-asset-tree` knows which realm to query for assets. 


## Screenshots
#### Select target button
<img width="1310" height="134" alt="image" src="https://github.com/user-attachments/assets/28029dca-f69a-4792-a428-117ed3dd850f" />

#### Select attributes dialog (attribute picker)
<img width="1341" height="909" alt="image" src="https://github.com/user-attachments/assets/84fa3540-cc40-4e73-888f-ec07ef336cd5" />

#### When an attribute has been selected
<img width="1310" height="134" alt="image" src="https://github.com/user-attachments/assets/2371e4c3-8ee8-41c2-b25e-2e2131af0a3c" />
Clicking on the Asset/Attribute will show the dialog again to modify it

#### Regressors
<img width="1310" height="134" alt="image" src="https://github.com/user-attachments/assets/230f08d5-0f7e-4c2d-b0f8-32096d793f1b" />
Functions the same as the target, but has an extra meta item requirement for the attribute
<img width="539" height="111" alt="image" src="https://github.com/user-attachments/assets/e1211801-0fad-4f69-aaa8-58c06d1e1a9c" />




