### PR TITLE
Render breadcrumbs based on context and router meta data

### DIFF
--- a/frontend/src/components/breadcrumb-nav.ts
+++ b/frontend/src/components/breadcrumb-nav.ts
@@ -131,7 +131,7 @@ export class BreadcrumbNav extends LitElement {
     protected updateBreadcrumbs(location: RouterLocation): void {
         const parts: BreadcrumbPart[] = [];
         const segments = location.pathname.split('/').filter(Boolean);
-        
+
         // Remove base path segments if present
         const rootSegments = this.rootPath.split('/').filter(Boolean);
         const pathSegments = segments.slice(rootSegments.length);
@@ -151,7 +151,7 @@ export class BreadcrumbNav extends LitElement {
             accumulatedPath += `/${segment}`;
 
             if (segment === this.realm) continue; // Skip realm in path (already in base)
-            
+
             const label = this.getLabelForSegment(segment, location.params);
             if (label) {
                 parts.push({ path: accumulatedPath, label });
@@ -166,8 +166,8 @@ export class BreadcrumbNav extends LitElement {
      */
     protected getLabelForSegment(segment: string, params: RouterLocation['params']): string | null {
         const segmentMap: Record<string, string> = {
-            'configs': 'Configs',
-            'new': 'New Config'
+            configs: 'Configs',
+            new: 'New Config'
         };
 
         // Check if segment is a known label

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -25,6 +25,12 @@ import { Router } from '@vaadin/router';
 import { getRootPath } from './common/util';
 import { APP_OUTLET } from './common/constants';
 
+export interface BreadcrumbMeta {
+    label?: string;
+    icon?: string;
+    hideInEmbedded?: boolean;
+}
+
 const routes = [
     {
         path: '',
@@ -37,17 +43,20 @@ const routes = [
             {
                 path: `/:realm/configs`,
                 component: 'page-config-list',
-                title: 'Configs'
+                title: 'Configs',
+                breadcrumb: { label: 'Configs', hideInEmbedded: false } as BreadcrumbMeta
             },
             {
                 path: `/:realm/configs/new`,
                 component: 'page-config-editor',
-                title: 'New Config'
+                title: 'New Config',
+                breadcrumb: { label: 'New Config', hideInEmbedded: false } as BreadcrumbMeta
             },
             {
                 path: `/:realm/configs/:id`,
                 component: 'page-config-editor',
-                title: 'Edit Config'
+                title: 'Edit Config',
+                breadcrumb: { label: ':id', hideInEmbedded: false } as BreadcrumbMeta
             },
             {
                 path: '(.*)',


### PR DESCRIPTION
Refactor for the breadcrumbs/navigational section

This PR adds metadata for breadcrumbs to the routes and makes the component context-aware (embedded or standalone).

### Embedded context examples
In the embedded context the breadcrumbs that do not provide any value are hidden
<img width="1870" height="586" alt="image" src="https://github.com/user-attachments/assets/26cc2dd3-24d9-4149-9f1b-1d4bb201b685" />
<img width="1870" height="586" alt="image" src="https://github.com/user-attachments/assets/b273d04b-9983-4b47-8407-0c7feb452e9f" />

### Standalone context examples
<img width="1870" height="586" alt="image" src="https://github.com/user-attachments/assets/cf390335-8c4d-4ce3-ba82-0e724dc2b433" />
<img width="1870" height="586" alt="image" src="https://github.com/user-attachments/assets/9691359e-9894-4732-9a85-d50d13658c7b" />
