### PR TITLE
Bugfix: Fix 422 Error when creating a model config with an attribute name that has less than 3 characters

### DIFF
--- a/src/service_ml_forecast/models/model_config.py
+++ b/src/service_ml_forecast/models/model_config.py
@@ -33,7 +33,7 @@ class RegressorAssetDatapointsFeature(BaseModel):
     asset_id: str = Field(description="ID of the asset from OpenRemote.", min_length=22, max_length=22)
     attribute_name: str = Field(
         description="Name of the attribute of the asset.",
-        min_length=3,
+        min_length=1,
     )
     training_data_period: str = Field(
         default="P6M",
@@ -61,7 +61,7 @@ class TargetAssetDatapointsFeature(BaseModel):
     asset_id: str = Field(description="ID of the asset from OpenRemote.", min_length=22, max_length=22)
     attribute_name: str = Field(
         description="Name of the attribute of the asset.",
-        min_length=3,
+        min_length=1,
     )
     training_data_period: str = Field(
         default="P6M",


### PR DESCRIPTION
Closes #57 

min_length was set to 3 for the `attribute_name` property for the model config features (e.g. target attribute, regressor attribute).

This PR sets the min length to 1