### PR TITLE
Deprecate training_interval config item

### DIFF
--- a/frontend/src/pages/pages-config-editor.ts
+++ b/frontend/src/pages/pages-config-editor.ts
@@ -193,7 +193,6 @@ export class PageConfigEditor extends LitElement {
         forecast_interval: 'PT1H',
         forecast_periods: 24,
         forecast_frequency: '1h',
-        training_interval: 'PT1H',
         daily_seasonality: true,
         weekly_seasonality: true,
         yearly_seasonality: true,
@@ -746,22 +745,6 @@ export class PageConfigEditor extends LitElement {
                                 label="Training data period"
                                 .iso_units="${[TimeDurationUnit.DAY, TimeDurationUnit.WEEK, TimeDurationUnit.MONTH, TimeDurationUnit.YEAR]}"
                                 .value="${this.formData.target.training_data_period}"
-                            ></custom-duration-input>
-                        </div>
-                    </div>
-                </or-panel>
-
-                <!-- Model training, e.g the schedule-->
-                <or-panel heading="MODEL TRAINING">
-                    <div class="column">
-                        <div class="row">
-                            <!-- Training interval (ISO 8601) -->
-                            <custom-duration-input
-                                name="training_interval"
-                                .type="${DurationInputType.ISO_8601}"
-                                @value-changed="${this.handleBasicInput}"
-                                label="Train model every"
-                                .value="${this.formData.training_interval}"
                             ></custom-duration-input>
                         </div>
                     </div>

--- a/frontend/src/services/models.ts
+++ b/frontend/src/services/models.ts
@@ -109,10 +109,6 @@ interface BaseModelConfig {
      */
     forecast_interval: string;
     /**
-     * Model training interval. Expects ISO 8601 duration strings.
-     */
-    training_interval: string;
-    /**
      * Number of periods to forecast into the future.
      */
     forecast_periods: number;

--- a/src/service_ml_forecast/models/model_config.py
+++ b/src/service_ml_forecast/models/model_config.py
@@ -99,8 +99,17 @@ class BaseModelConfig(BaseModel):
         "There must be historical data available for training. "
         "There must also be future data available for forecasting.",
     )
-    forecast_interval: str = Field(description="Forecast generation interval. Expects ISO 8601 duration strings.")
-    training_interval: str = Field(description="Model training interval. Expects ISO 8601 duration strings.")
+    forecast_interval: str = Field(
+        description="Forecast generation interval. "
+        "Training is always executed before the forecast job. "
+        "Expects ISO 8601 duration strings."
+    )
+    training_interval: str | None = Field(
+        default=None,
+        description="Deprecated. Uses forecast_interval now instead (train > forecast order). Model training interval. "
+        "Expects ISO 8601 duration strings.",
+        deprecated=True,
+    )
     forecast_periods: int = Field(description="Number of periods to forecast.")
     forecast_frequency: str = Field(
         description="The frequency of each forecasted datapoint. "

--- a/src/service_ml_forecast/models/model_config.py
+++ b/src/service_ml_forecast/models/model_config.py
@@ -106,8 +106,7 @@ class BaseModelConfig(BaseModel):
     )
     training_interval: str | None = Field(
         default=None,
-        description="Deprecated. Uses forecast_interval instead. Model training interval. "
-        "Expects ISO 8601 duration strings.",
+        description="Deprecated. Use forecast_interval instead.",
         deprecated=True,
     )
     forecast_periods: int = Field(description="Number of periods to forecast.")

--- a/src/service_ml_forecast/models/model_config.py
+++ b/src/service_ml_forecast/models/model_config.py
@@ -106,7 +106,7 @@ class BaseModelConfig(BaseModel):
     )
     training_interval: str | None = Field(
         default=None,
-        description="Deprecated. Uses forecast_interval now instead (train > forecast order). Model training interval. "
+        description="Deprecated. Uses forecast_interval instead. Model training interval. "
         "Expects ISO 8601 duration strings.",
         deprecated=True,
     )

--- a/src/service_ml_forecast/services/model_scheduler.py
+++ b/src/service_ml_forecast/services/model_scheduler.py
@@ -92,7 +92,7 @@ class ModelScheduler(Singleton):
         """Add a training job for the given model config."""
 
         job_id = f"{TRAINING_JOB_ID_PREFIX}:{config.id}"
-        seconds = TimeUtil.parse_iso_duration(config.training_interval)
+        seconds = TimeUtil.parse_iso_duration(config.forecast_interval)
 
         if not self._is_job_scheduling_needed(job_id, config):
             return
@@ -195,7 +195,7 @@ def _model_training_job(config: ModelConfig, data_service: OpenRemoteService) ->
     if model is None:
         logger.error(
             f"Model training failed for {config.id} - no model returned. "
-            f"Type: {config.type}, Training Interval: {config.training_interval}"
+            f"Type: {config.type}, Interval: {config.forecast_interval}"
         )
         return
 
@@ -209,7 +209,7 @@ def _model_training_job(config: ModelConfig, data_service: OpenRemoteService) ->
     end_time = time.perf_counter()
     logger.info(
         f"Training job for {config.id} completed - duration: {end_time - start_time}s, "
-        f"Type: {config.type}, Training Interval: {config.training_interval}, "
+        f"Type: {config.type}, Interval: {config.forecast_interval}, "
         f"Target first datapoint datetime: {target_first_datapoint_datetime}, "
         f"Target last datapoint datetime: {target_last_datapoint_datetime}"
     )

--- a/tests/api/test_model_config_route.py
+++ b/tests/api/test_model_config_route.py
@@ -27,7 +27,6 @@ def create_test_config() -> dict[str, Any]:
             "training_data_period": TEST_training_data_period,
         },
         "forecast_interval": "PT1H",
-        "training_interval": "PT1H",
         "forecast_periods": 24,
         "forecast_frequency": "1h",
     }

--- a/tests/ml/resources/prophet-windspeed-config.json
+++ b/tests/ml/resources/prophet-windspeed-config.json
@@ -10,7 +10,6 @@
       "training_data_period": "P6M"
     },
     "forecast_interval": "PT60S",
-    "training_interval": "PT30S",
     "forecast_periods": 7,
     "forecast_frequency": "1h"
 }

--- a/tests/services/test_model_scheduler.py
+++ b/tests/services/test_model_scheduler.py
@@ -86,7 +86,7 @@ def test_scheduler_job_management(
     training_job = model_scheduler.scheduler.get_job(f"{TRAINING_JOB_ID_PREFIX}:{prophet_basic_config.id}")
     assert training_job is not None
     assert training_job.func == _model_training_job
-    expected_interval = datetime.timedelta(seconds=TimeUtil.parse_iso_duration(prophet_basic_config.training_interval))
+    expected_interval = datetime.timedelta(seconds=TimeUtil.parse_iso_duration(prophet_basic_config.forecast_interval))
     assert training_job.trigger.interval == expected_interval
 
     # Remove the config and check that the jobs are removed


### PR DESCRIPTION
Closes #54

- `training_interval` has been replaced with `forecast_interval` where applicable (job scheduler logic).
  > The training job is always executed before the forecasting job, so no changes to the job execution logic were required.

- The front-end config editor no longer includes a `training` section, as it is no longer needed.
- The `forecast_interval` property in `model_config.py` has been marked as deprecated. It remains part of the model to ensure backward compatibility

I also verified that existing configurations which still define `training_interval` load correctly and that forecasting is executed as expected. 
