### PR TITLE
Inject runtime URLs in the back-end served index.html

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,18 +11,8 @@ RUN npm install
 
 COPY frontend/ ./
 
-# Define build arguments
-ARG ML_SERVICE_URL
-ARG ML_WEB_ROOT_PATH
-ARG ML_OR_KEYCLOAK_URL
-ARG ML_OR_URL
-
 # Run the front-end bundle in production mode
-RUN ML_SERVICE_URL=${ML_SERVICE_URL:-/services/ml-forecast} \
-    ML_WEB_ROOT_PATH=${ML_WEB_ROOT_PATH:-/services/ml-forecast/ui} \
-    ML_OR_KEYCLOAK_URL=${ML_OR_KEYCLOAK_URL:-/auth} \
-    ML_OR_URL=${ML_OR_URL:-} \
-    npm run build:prod
+RUN npm run build:prod
 
 # --- Python Build Phase -------------------------------------------------------
 FROM python:3.13-slim AS builder

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,11 +5,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-      args:
-        ML_OR_URL: ${ML_OR_URL} # OpenRemote URL
-        ML_OR_KEYCLOAK_URL: ${ML_OR_KEYCLOAK_URL} # OpenRemote Keycloak URL
-        ML_SERVICE_URL: ${ML_SERVICE_URL} # Url to reach the back-end service, should be the same as ML_API_ROOT_PATH
-        ML_WEB_ROOT_PATH: ${ML_WEB_ROOT_PATH} # Public path for the front-end (e.g. when behind a reverse proxy)
     container_name: service-ml-forecast
     ports:
       - "8000:8000"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,6 +29,9 @@
                 min-width: fit-content;
             }
         </style>
+        <script id="ml-runtime-config" type="application/json">
+            __ML_RUNTIME_CONFIG__
+        </script>
     </head>
 
     <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,8 +29,8 @@
                 min-width: fit-content;
             }
         </style>
-        <script id="ml-runtime-config" type="application/json">
-            __ML_RUNTIME_CONFIG__
+        <script>
+            window.APP_CONFIG = __ML_RUNTIME_CONFIG__;
         </script>
     </head>
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,9 @@
     "version": "0.0.0",
     "type": "module",
     "scripts": {
-        "serve": "cross-env rspack serve",
-        "build:dev": "cross-env ML_OR_KEYCLOAK_URL=${ML_OR_KEYCLOAK_URL:-http://localhost:8081/auth} ML_OR_URL=${ML_OR_URL:-http://localhost:8080} ML_SERVICE_URL=${ML_SERVICE_URL:-/services/ml-forecast} ML_WEB_ROOT_PATH=${ML_WEB_ROOT_PATH:-/services/ml-forecast/ui} rspack build --mode development",
-        "build:prod": "cross-env ML_OR_KEYCLOAK_URL=${ML_OR_KEYCLOAK_URL:-/auth} ML_OR_URL=${ML_OR_URL} ML_SERVICE_URL=${ML_SERVICE_URL:-/services/ml-forecast} ML_WEB_ROOT_PATH=${ML_WEB_ROOT_PATH:-/services/ml-forecast/ui} rspack build --mode production",
+        "serve": "rspack serve",
+        "build:dev": "rspack build --mode development",
+        "build:prod": "rspack build --mode production",
         "build:analyze": "rspack build --mode production --analyze",
         "lint": "eslint && prettier . --check",
         "format": "prettier . --write"

--- a/frontend/rspack.config.js
+++ b/frontend/rspack.config.js
@@ -7,10 +7,23 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const isProduction = process.env.NODE_ENV === 'production';
-const rootPath = process.env.ML_WEB_ROOT_PATH;
-const serviceUrl = process.env.ML_SERVICE_URL || 'http://localhost:8000'; // Default to default service backend
-const keycloakUrl = process.env.ML_OR_KEYCLOAK_URL || 'http://localhost:8081/auth'; // Default to openremote keycloak address
-const openremoteUrl = process.env.ML_OR_URL !== undefined ? process.env.ML_OR_URL : 'http://localhost:8080'; // Default to openremote url
+
+const rootPath = '/services/ml-forecast/ui';
+const devEnvDefaults = {
+    ML_SERVICE_URL: '/services/ml-forecast',
+    ML_OR_KEYCLOAK_URL: 'http://localhost:8081/auth',
+    ML_OR_URL: 'http://localhost:8080'
+};
+
+const definePlugin = isProduction
+    ? null
+    : new rspack.DefinePlugin({
+          'process.env.ML_SERVICE_URL': JSON.stringify(process.env.ML_SERVICE_URL || devEnvDefaults.ML_SERVICE_URL),
+          'process.env.ML_OR_KEYCLOAK_URL': JSON.stringify(
+              process.env.ML_OR_KEYCLOAK_URL || devEnvDefaults.ML_OR_KEYCLOAK_URL
+          ),
+          'process.env.ML_OR_URL': JSON.stringify(process.env.ML_OR_URL || devEnvDefaults.ML_OR_URL)
+      });
 
 export default {
     mode: isProduction ? 'production' : 'development',
@@ -65,11 +78,7 @@ export default {
         new rspack.CopyRspackPlugin({
             patterns: [{ from: 'assets', to: 'assets' }]
         }),
-        new rspack.DefinePlugin({
-            'process.env.ML_SERVICE_URL': JSON.stringify(serviceUrl),
-            'process.env.ML_OR_KEYCLOAK_URL': JSON.stringify(keycloakUrl),
-            'process.env.ML_OR_URL': JSON.stringify(openremoteUrl)
-        })
+        ...(definePlugin ? [definePlugin] : [])
     ],
     devServer: {
         port: 8001,

--- a/frontend/rspack.config.js
+++ b/frontend/rspack.config.js
@@ -19,9 +19,7 @@ const definePlugin = isProduction
     ? null
     : new rspack.DefinePlugin({
           'process.env.ML_SERVICE_URL': JSON.stringify(process.env.ML_SERVICE_URL || devEnvDefaults.ML_SERVICE_URL),
-          'process.env.ML_OR_KEYCLOAK_URL': JSON.stringify(
-              process.env.ML_OR_KEYCLOAK_URL || devEnvDefaults.ML_OR_KEYCLOAK_URL
-          ),
+          'process.env.ML_OR_KEYCLOAK_URL': JSON.stringify(process.env.ML_OR_KEYCLOAK_URL || devEnvDefaults.ML_OR_KEYCLOAK_URL),
           'process.env.ML_OR_URL': JSON.stringify(process.env.ML_OR_URL || devEnvDefaults.ML_OR_URL)
       });
 

--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -18,7 +18,19 @@
 export const APP_OUTLET = document.querySelector('#outlet') as HTMLElement;
 export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 export const ML_SERVICE_URL = (process.env.ML_SERVICE_URL || '').replace(/\/$/, '');
-export const ML_OR_URL = process.env.ML_OR_URL || '';
+const resolveManagerUrl = (value: string): string => {
+    if (!value) {
+        return window.location.origin;
+    }
+
+    if (value.startsWith('/')) {
+        return `${window.location.origin}${value}`;
+    }
+
+    return value.replace(/\/$/, '');
+};
+
+export const ML_OR_URL = resolveManagerUrl(process.env.ML_OR_URL || '');
 export const ML_OR_KEYCLOAK_URL = process.env.ML_OR_KEYCLOAK_URL || '';
 
 // Returns true if the app is embedded in an iframe

--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -22,28 +22,21 @@ type RuntimeConfig = {
     ML_OR_KEYCLOAK_URL?: string;
 };
 
-const getRuntimeConfig = (): RuntimeConfig => {
-    const configElement = document.getElementById('ml-runtime-config');
-    if (!configElement?.textContent) {
-        return {};
+declare global {
+    interface Window {
+        APP_CONFIG?: RuntimeConfig;
     }
+}
 
-    try {
-        return JSON.parse(configElement.textContent) as RuntimeConfig;
-    } catch {
-        return {};
-    }
-};
-
-const runtimeConfig = getRuntimeConfig();
+const runtimeConfig = window.APP_CONFIG ?? {};
 const bundledEnv = typeof process !== 'undefined' ? process.env : undefined;
 
 export const IS_DEVELOPMENT = bundledEnv?.NODE_ENV === 'development';
 
-export const ML_SERVICE_URL = (runtimeConfig.ML_SERVICE_URL || bundledEnv?.ML_SERVICE_URL || '').replace(/\/$/, '');
+export const ML_SERVICE_URL = (runtimeConfig.ML_SERVICE_URL ?? bundledEnv?.ML_SERVICE_URL ?? '').replace(/\/$/, '');
 
-export const ML_OR_URL = runtimeConfig.ML_OR_URL || bundledEnv?.ML_OR_URL || '';
-export const ML_OR_KEYCLOAK_URL = runtimeConfig.ML_OR_KEYCLOAK_URL || bundledEnv?.ML_OR_KEYCLOAK_URL || '';
+export const ML_OR_URL = runtimeConfig.ML_OR_URL ?? bundledEnv?.ML_OR_URL ?? '';
+export const ML_OR_KEYCLOAK_URL = runtimeConfig.ML_OR_KEYCLOAK_URL ?? bundledEnv?.ML_OR_KEYCLOAK_URL ?? '';
 
 // Returns true if the app is embedded in an iframe
 export const IS_EMBEDDED = window.top !== window.self;

--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -16,22 +16,34 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 export const APP_OUTLET = document.querySelector('#outlet') as HTMLElement;
-export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
-export const ML_SERVICE_URL = (process.env.ML_SERVICE_URL || '').replace(/\/$/, '');
-const resolveManagerUrl = (value: string): string => {
-    if (!value) {
-        return window.location.origin;
-    }
-
-    if (value.startsWith('/')) {
-        return `${window.location.origin}${value}`;
-    }
-
-    return value.replace(/\/$/, '');
+type RuntimeConfig = {
+    ML_SERVICE_URL?: string;
+    ML_OR_URL?: string;
+    ML_OR_KEYCLOAK_URL?: string;
 };
 
-export const ML_OR_URL = resolveManagerUrl(process.env.ML_OR_URL || '');
-export const ML_OR_KEYCLOAK_URL = process.env.ML_OR_KEYCLOAK_URL || '';
+const getRuntimeConfig = (): RuntimeConfig => {
+    const configElement = document.getElementById('ml-runtime-config');
+    if (!configElement?.textContent) {
+        return {};
+    }
+
+    try {
+        return JSON.parse(configElement.textContent) as RuntimeConfig;
+    } catch {
+        return {};
+    }
+};
+
+const runtimeConfig = getRuntimeConfig();
+const bundledEnv = typeof process !== 'undefined' ? process.env : undefined;
+
+export const IS_DEVELOPMENT = bundledEnv?.NODE_ENV === 'development';
+
+export const ML_SERVICE_URL = (runtimeConfig.ML_SERVICE_URL || bundledEnv?.ML_SERVICE_URL || '').replace(/\/$/, '');
+
+export const ML_OR_URL = runtimeConfig.ML_OR_URL || bundledEnv?.ML_OR_URL || '';
+export const ML_OR_KEYCLOAK_URL = runtimeConfig.ML_OR_KEYCLOAK_URL || bundledEnv?.ML_OR_KEYCLOAK_URL || '';
 
 // Returns true if the app is embedded in an iframe
 export const IS_EMBEDDED = window.top !== window.self;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -33,7 +33,7 @@ import './components/breadcrumb-nav';
 import './components/alert-message';
 
 const DEFAULT_MANAGER_CONFIG: ManagerConfig = {
-    managerUrl: ML_OR_URL,
+    managerUrl: ML_OR_URL ?? '/',
     keycloakUrl: ML_OR_KEYCLOAK_URL || '/auth',
     auth: Auth.KEYCLOAK,
     autoLogin: true,

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -33,7 +33,7 @@ import './components/breadcrumb-nav';
 import './components/alert-message';
 
 const DEFAULT_MANAGER_CONFIG: ManagerConfig = {
-    managerUrl: ML_OR_URL || '/',
+    managerUrl: ML_OR_URL,
     keycloakUrl: ML_OR_KEYCLOAK_URL || '/auth',
     auth: Auth.KEYCLOAK,
     autoLogin: true,

--- a/src/service_ml_forecast/api/web_route.py
+++ b/src/service_ml_forecast/api/web_route.py
@@ -21,14 +21,15 @@ Web API routes.
 These routes are used to serve the web application.
 """
 
+import json
 import logging
 from http import HTTPStatus
 
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 
-from service_ml_forecast.config import DIRS
+from service_ml_forecast.config import DIRS, ENV
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,24 @@ else:
     logger.error(f"Web dist directory not found at {DIRS.ML_WEBSERVER_UI_DIST_DIR}, bundle cannot be served")
 
 
+def _render_index_html() -> HTMLResponse:
+    """Render index.html with runtime config injected from server environment."""
+
+    index_path = DIRS.ML_WEBSERVER_UI_DIST_DIR / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="index.html not found")
+
+    runtime_config = {
+        "ML_SERVICE_URL": ENV.ML_API_ROOT_PATH,
+        "ML_OR_URL": ENV.ML_OR_URL,
+        "ML_OR_KEYCLOAK_URL": ENV.ML_OR_KEYCLOAK_URL,
+    }
+    config = json.dumps(runtime_config).replace("<", "\\u003c")
+    html = index_path.read_text(encoding="utf-8")
+    html = html.replace("__ML_RUNTIME_CONFIG__", config)
+    return HTMLResponse(content=html)
+
+
 @router.get(
     "/",
     summary="Serve the index.html file from the web dist directory.",
@@ -48,13 +67,10 @@ else:
         HTTPStatus.NOT_FOUND: {"description": "Index.html file not found"},
     },
 )
-def serve_index() -> FileResponse:
+def serve_index() -> HTMLResponse:
     """Serve the index.html file from the web dist directory."""
 
-    index_path = DIRS.ML_WEBSERVER_UI_DIST_DIR / "index.html"
-    if not index_path.exists():
-        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="index.html not found")
-    return FileResponse(index_path)
+    return _render_index_html()
 
 
 @router.get(
@@ -65,7 +81,7 @@ def serve_index() -> FileResponse:
         HTTPStatus.NOT_FOUND: {"description": "Static file not found"},
     },
 )
-def serve_spa(path: str) -> FileResponse:
+def serve_spa(path: str) -> Response:
     """Serve static files or return index.html for SPA routing."""
 
     requested_path = DIRS.ML_WEBSERVER_UI_DIST_DIR / path
@@ -75,7 +91,4 @@ def serve_spa(path: str) -> FileResponse:
         return FileResponse(requested_path)
 
     # Return index.html for client-side routing
-    index_path = DIRS.ML_WEBSERVER_UI_DIST_DIR / "index.html"
-    if not index_path.exists():
-        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="index.html not found")
-    return FileResponse(index_path)
+    return _render_index_html()


### PR DESCRIPTION
Closes #65 

Currently the front-end bundle contains relative URLs that are embedded during its built process. This bundle is then served by the back-end service.

This change allows the back-end to dynamically inject the configured server URL environment variables into the served `index.html` which is then used by the front-end as runtime config. This is more flexible and reliable than relying on embedded relative URLs. It only injects the necessary variables and does not expose anything else.

**The change also resolves an issue where the WS subscription would fail** since the `ManagerConfig` expects the managerUrl to be absolute (e.g. containing the full address), to determine whether it should use WS or WSS.
```
this._endpointUrl = (managerUrl.startsWith("https:") ? "wss" : "ws") + "://" + managerUrl.substr(managerUrl.indexOf("://") + 3) + "/websocket/events";
```