### PR TITLE
Bugfix/Fix front-end not applying default realm styles

### DIFF
--- a/frontend/src/common/theme.ts
+++ b/frontend/src/common/theme.ts
@@ -95,7 +95,7 @@ export async function setRealmTheme(realm: string) {
 
     try {
         const config = (await manager.rest.api.ConfigurationResource.getManagerConfig()).data;
-        const styles = config.realms?.[realm]?.styles;
+        const styles = config.realms?.[realm]?.styles ?? config.realms?.default?.styles;
 
         if (styles) {
             const cssString = styles;


### PR DESCRIPTION
I've noticed that the ui doesn't apply the default styles and only tries to apply realm styling. This PR fixes that.